### PR TITLE
drm: Fix Mesa driver names, add mapping of amdgpu kernel driver to radeonsi Mesa driver

### DIFF
--- a/va/drm/va_drm_utils.c
+++ b/va/drm/va_drm_utils.c
@@ -43,6 +43,7 @@ static const struct driver_name_map g_driver_name_map[] = {
     { "hybrid",     6, "hybrid" }, // Intel OTC Hybrid driver
     { "nouveau",    7, "nouveau"  }, // Mesa Gallium driver
     { "radeon",     6, "r600"     }, // Mesa Gallium driver
+    { "amdgpu",     6, "radeonsi" }, // Mesa Gallium driver
     { NULL, }
 };
 

--- a/va/drm/va_drm_utils.c
+++ b/va/drm/va_drm_utils.c
@@ -41,8 +41,8 @@ static const struct driver_name_map g_driver_name_map[] = {
     { "pvrsrvkm",   8, "pvr"    }, // Intel UMG PVR driver
     { "emgd",       4, "emgd"   }, // Intel ECG PVR driver
     { "hybrid",     6, "hybrid" }, // Intel OTC Hybrid driver
-    { "nouveau",    7, "gallium" }, // Mesa Gallium driver
-    { "radeon",     6, "gallium" }, // Mesa Gallium driver
+    { "nouveau",    7, "nouveau"  }, // Mesa Gallium driver
+    { "radeon",     6, "r600"     }, // Mesa Gallium driver
     { NULL, }
 };
 


### PR DESCRIPTION
As ML.