### PR TITLE
android: move libva-android to /vendor

### DIFF
--- a/va/Android.mk
+++ b/va/Android.mk
@@ -89,6 +89,7 @@ LOCAL_C_INCLUDES += \
 
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE := libva-android
+LOCAL_PROPRIETARY_MODULE := true
 
 LOCAL_SHARED_LIBRARIES := libva libdrm
 

--- a/va/Android.mk
+++ b/va/Android.mk
@@ -93,39 +93,3 @@ LOCAL_MODULE := libva-android
 LOCAL_SHARED_LIBRARIES := libva libdrm
 
 include $(BUILD_SHARED_LIBRARY)
-
-
-# For libva-egl
-# =====================================================
-
-include $(CLEAR_VARS)
-
-LOCAL_SRC_FILES := \
-	egl/va_egl.c
-
-LOCAL_CFLAGS += \
-	-DLOG_TAG=\"libva-egl\"
-
-LOCAL_MODULE_TAGS := optional
-LOCAL_MODULE := libva-egl
-
-LOCAL_SHARED_LIBRARIES := libva
-
-include $(BUILD_SHARED_LIBRARY)
-
-
-# For libva-tpi
-# =====================================================
-
-include $(CLEAR_VARS)
-
-LOCAL_SRC_FILES := va_tpi.c
-
-LOCAL_CFLAGS += -DLOG_TAG=\"libva-tpi\"
-
-LOCAL_SHARED_LIBRARIES := libva
-
-LOCAL_MODULE_TAGS := optional
-LOCAL_MODULE := libva-tpi
-
-include $(BUILD_SHARED_LIBRARY)


### PR DESCRIPTION
This was missed in the previous commit bed97ef.