### PR TITLE
android: open renderD128 by default

### DIFF
--- a/va/android/va_android.cpp
+++ b/va/android/va_android.cpp
@@ -41,7 +41,7 @@
 
 
 #define CHECK_SYMBOL(func) { if (!func) printf("func %s not found\n", #func); return VA_STATUS_ERROR_UNKNOWN; }
-#define DEVICE_NAME "/dev/dri/card0"
+#define DEVICE_NAME "/dev/dri/renderD128"
 
 static int open_device (char *dev_name)
 {


### PR DESCRIPTION
if we open card0, we need be a root to call I915_PARAM_CHIPSET_ID,
but mediaservice's owner is not root, open renderD128 will fix this.