### PR TITLE
add/redefine attribute value for VAConfigAttribEncSliceStructure,

### DIFF
--- a/va/va.h
+++ b/va/va.h
@@ -585,12 +585,16 @@ typedef struct _VAConfigAttrib {
 
 /** @name Attribute values for VAConfigAttribEncSliceStructure */
 /**@{*/
-/** \brief Driver supports an arbitrary number of rows per slice. */
-#define VA_ENC_SLICE_STRUCTURE_ARBITRARY_ROWS           0x00000000
 /** \brief Driver supports a power-of-two number of rows per slice. */
 #define VA_ENC_SLICE_STRUCTURE_POWER_OF_TWO_ROWS        0x00000001
 /** \brief Driver supports an arbitrary number of rows per slice. */
 #define VA_ENC_SLICE_STRUCTURE_ARBITRARY_MACROBLOCKS    0x00000002
+/** \brief Dirver support 1 rows per slice */
+#define VA_ENC_SLICE_STRUCTURE_EQUAL_ROWS               0x00000004
+/** \brief Dirver support max encoded slice size */
+#define VA_ENC_SLICE_STRUCTURE_MAX_SLICE_SIZE           0x00000008
+/** \brief Driver supports an arbitrary number of rows per slice. */
+#define VA_ENC_SLICE_STRUCTURE_ARBITRARY_ROWS           0x00000016
 /**@}*/
 
 /** \brief Attribute value for VAConfigAttribEncJPEG */


### PR DESCRIPTION
redefine VAENC_SLICE_STRUCTURE_ARBITRARY_ROW to non-zero value
then all attributes of VAConfigAttribEncSliceStructure can be OR'd together.