### PR TITLE
Refine the data type of slice_data_flag in VASliceParameterBufferHEVC…

### DIFF
--- a/va/va_dec_hevc.h
+++ b/va/va_dec_hevc.h
@@ -254,7 +254,7 @@ typedef struct  _VASliceParameterBufferHEVC
     /** \brief The offset to the NAL unit header for this slice */
     uint32_t                slice_data_offset;
     /** \brief Slice data buffer flags. See \c VA_SLICE_DATA_FLAG_XXX. */
-    uint16_t                slice_data_flag;
+    uint32_t                slice_data_flag;
     /**
      * \brief Byte offset from NAL unit header to the begining of slice_data().
      *


### PR DESCRIPTION
… to be consistent with other codecs

Currently the data type of slice_data_flag in VASliceParameterBufferHEVC is
uint16_t while it is uint32_t for other codecs. It is inconsistent.
As the memory is allocated as aligned, it still allocates four bytes for it.
So it will be better to use the consistent data type.

This fixes https://github.com/01org/libva/issues/58

Signed-off-by: Zhao Yakui <yakui.zhao@intel.com>