### PR TITLE
wayland: Also support wl_drm version 1

### DIFF
--- a/va/wayland/va_wayland_drm.c
+++ b/va/wayland/va_wayland_drm.c
@@ -172,8 +172,12 @@ registry_handle_global(
     struct va_wayland_drm_context *wl_drm_ctx = data;
 
     if (strcmp(interface, "wl_drm") == 0) {
+        /* bind to at most version 2, but also support version 1 if
+         * compositor does not have v2
+         */
         wl_drm_ctx->drm =
-            wl_registry_bind(wl_drm_ctx->registry, id, wl_drm_ctx->drm_interface, 2);
+            wl_registry_bind(wl_drm_ctx->registry, id, wl_drm_ctx->drm_interface,
+                             (version < 2) ? version : 2);
     }
 }
 


### PR DESCRIPTION
Just using version 2 without checking would lead to a protocol error
bringing down the entire application, and wl_drm version 1 is still
supported since v2 only adds PRIME capabilities.

That wl_drm v1 is still supported is more of an assumption of mine :-) If it isn't, there still should be a version check so the library can output an error and not bind the interface. If you try to bind the interface with an invalid version, a protocol error will result and the whole application will go down.