### PR TITLE
Miscellaneous changes for libva2

### DIFF
--- a/va/android/va_android.cpp
+++ b/va/android/va_android.cpp
@@ -26,6 +26,7 @@
 #include "sysdeps.h"
 #include "va.h"
 #include "va_backend.h"
+#include "va_internal.h"
 #include "va_trace.h"
 #include "va_fool.h"
 #include "va_android.h"
@@ -135,13 +136,11 @@ VADisplay vaGetDisplay (
         /* create new entry */
         VADriverContextP pDriverContext = 0;
         struct drm_state *drm_state = 0;
-        pDisplayContext = (VADisplayContextP)calloc(1, sizeof(*pDisplayContext));
+        pDisplayContext = va_newDisplayContext();
         pDriverContext  = (VADriverContextP)calloc(1, sizeof(*pDriverContext));
         drm_state       = (struct drm_state*)calloc(1, sizeof(*drm_state));
         if (pDisplayContext && pDriverContext && drm_state)
         {
-            pDisplayContext->vadpy_magic = VA_DISPLAY_MAGIC;          
-
             pDriverContext->native_dpy       = (void *)native_dpy;
             pDriverContext->display_type     = VA_DISPLAY_ANDROID;
             pDisplayContext->pDriverContext  = pDriverContext;

--- a/va/android/va_android.cpp
+++ b/va/android/va_android.cpp
@@ -165,9 +165,6 @@ VADisplay vaGetDisplay (
     return dpy;
 }
 
-#define CTX(dpy) (((VADisplayContextP)dpy)->pDriverContext)
-#define CHECK_DISPLAY(dpy) if( !vaDisplayIsValid(dpy) ) { return VA_STATUS_ERROR_INVALID_DISPLAY; }
-
 
 extern "C"  {
     extern int fool_postp; /* do nothing for vaPutSurface if set */

--- a/va/android/va_android.cpp
+++ b/va/android/va_android.cpp
@@ -166,8 +166,8 @@ VADisplay vaGetDisplay (
 
 
 extern "C"  {
-    extern int fool_postp; /* do nothing for vaPutSurface if set */
-    extern int trace_flag; /* trace vaPutSurface parameters */
+    extern int va_fool_postp; /* do nothing for vaPutSurface if set */
+    extern int va_trace_flag; /* trace vaPutSurface parameters */
 
     void va_TracePutSurface (
         VADisplay dpy,

--- a/va/drm/va_drm.c
+++ b/va/drm/va_drm.c
@@ -26,6 +26,7 @@
 #include <xf86drm.h>
 #include "va_drm.h"
 #include "va_backend.h"
+#include "va_internal.h"
 #include "va_drmcommon.h"
 #include "va_drm_auth.h"
 #include "va_drm_utils.h"
@@ -109,11 +110,10 @@ vaGetDisplayDRM(int fd)
         VA_DISPLAY_DRM_RENDERNODES : VA_DISPLAY_DRM;
     pDriverContext->drm_state    = drm_state;
 
-    pDisplayContext = calloc(1, sizeof(*pDisplayContext));
+    pDisplayContext = va_newDisplayContext();
     if (!pDisplayContext)
         goto error;
 
-    pDisplayContext->vadpy_magic     = VA_DISPLAY_MAGIC;
     pDisplayContext->pDriverContext  = pDriverContext;
     pDisplayContext->vaIsValid       = va_DisplayContextIsValid;
     pDisplayContext->vaDestroy       = va_DisplayContextDestroy;

--- a/va/egl/va_egl.c
+++ b/va/egl/va_egl.c
@@ -57,9 +57,8 @@
 #include "va.h"
 #include "va_backend_egl.h"
 #include "va_egl.h"
+#include "va_internal.h"
 
-#define CTX(dpy) (((VADisplayContextP)dpy)->pDriverContext)
-#define CHECK_DISPLAY(dpy) if( !vaDisplayIsValid(dpy) ) { return VA_STATUS_ERROR_INVALID_DISPLAY; }
 
 VAStatus vaGetEGLClientBufferFromSurface (
     VADisplay dpy,

--- a/va/va.c
+++ b/va/va.c
@@ -50,9 +50,6 @@
 
 #define DRIVER_EXTENSION	"_drv_video.so"
 
-#define CTX(dpy) (((VADisplayContextP)dpy)->pDriverContext)
-#define CHECK_DISPLAY(dpy) if( !vaDisplayIsValid(dpy) ) { return VA_STATUS_ERROR_INVALID_DISPLAY; }
-
 #define ASSERT		assert
 #define CHECK_VTABLE(s, ctx, func) if (!va_checkVtable(ctx->vtable->va##func, #func)) s = VA_STATUS_ERROR_UNKNOWN;
 #define CHECK_MAXIMUM(s, ctx, var) if (!va_checkMaximum(ctx->max_##var, #var)) s = VA_STATUS_ERROR_UNKNOWN;

--- a/va/va.c
+++ b/va/va.c
@@ -27,6 +27,7 @@
 #include "va.h"
 #include "va_backend.h"
 #include "va_backend_vpp.h"
+#include "va_internal.h"
 #include "va_trace.h"
 #include "va_fool.h"
 
@@ -232,6 +233,17 @@ void va_infoMessage(const char *msg, ...)
     else if (len > 0)
         va_log_info(buf);
 #endif
+}
+
+VADisplayContextP va_newDisplayContext(void)
+{
+    VADisplayContextP dctx = calloc(1, sizeof(*dctx));
+    if (!dctx)
+        return NULL;
+
+    dctx->vadpy_magic = VA_DISPLAY_MAGIC;
+
+    return dctx;
 }
 
 static bool va_checkVtable(void *ptr, char *function)

--- a/va/va.h
+++ b/va/va.h
@@ -231,19 +231,19 @@ typedef struct _VARectangle
 } VARectangle;
 
 /** Type of a message callback, used for both error and info log. */
-typedef void (*vaMessageCallback)(const char *message);
+typedef void (*VAMessageCallback)(void *user_context, const char *message);
 
 /**
  * Set the callback for error messages, or NULL for no logging.
  * Returns the previous one, or NULL if it was disabled.
  */
-vaMessageCallback vaSetErrorCallback(vaMessageCallback);
+VAMessageCallback vaSetErrorCallback(VADisplay dpy, VAMessageCallback callback, void *user_context);
 
 /**
  * Set the callback for info messages, or NULL for no logging.
  * Returns the previous one, or NULL if it was disabled.
  */
-vaMessageCallback vaSetInfoCallback(vaMessageCallback);
+VAMessageCallback vaSetInfoCallback(VADisplay dpy, VAMessageCallback callback, void *user_context);
 
 /**
  * Initialization:

--- a/va/va.h
+++ b/va/va.h
@@ -86,6 +86,18 @@
 extern "C" {
 #endif
 
+#ifdef __GNUC__
+#define va_deprecated __attribute__((deprecated))
+#if __GNUC__ >= 6
+#define va_deprecated_enum va_deprecated
+#else
+#define va_deprecated_enum
+#endif
+#else
+#define va_deprecated
+#define va_deprecated_enum
+#endif
+
 /**
  * \mainpage Video Acceleration (VA) API
  *

--- a/va/va.h
+++ b/va/va.h
@@ -1979,7 +1979,7 @@ typedef struct _VAPictureParameterBufferH264
     union {
         struct {
             unsigned int chroma_format_idc			: 2; 
-            unsigned int residual_colour_transform_flag		: 1; 
+            unsigned int residual_colour_transform_flag		: 1; /* Renamed to separate_colour_plane_flag in newer standard versions. */
             unsigned int gaps_in_frame_num_value_allowed_flag	: 1; 
             unsigned int frame_mbs_only_flag			: 1; 
             unsigned int mb_adaptive_frame_field_flag		: 1; 
@@ -2008,7 +2008,7 @@ typedef struct _VAPictureParameterBufferH264
             unsigned int transform_8x8_mode_flag	: 1;
             unsigned int field_pic_flag			: 1;
             unsigned int constrained_intra_pred_flag	: 1;
-            unsigned int pic_order_present_flag			: 1;
+            unsigned int pic_order_present_flag			: 1; /* Renamed to bottom_field_pic_order_in_frame_present_flag in newer standard versions. */
             unsigned int deblocking_filter_control_present_flag : 1;
             unsigned int redundant_pic_cnt_present_flag		: 1;
             unsigned int reference_pic_flag			: 1; /* nal_ref_idc != 0 */

--- a/va/va.h
+++ b/va/va.h
@@ -324,7 +324,7 @@ typedef enum
     VAProfileMPEG4Simple		= 2,
     VAProfileMPEG4AdvancedSimple	= 3,
     VAProfileMPEG4Main			= 4,
-    VAProfileH264Baseline		= 5,
+    VAProfileH264Baseline va_deprecated_enum = 5,
     VAProfileH264Main			= 6,
     VAProfileH264High			= 7,
     VAProfileVC1Simple			= 8,
@@ -1992,9 +1992,10 @@ typedef struct _VAPictureParameterBufferH264
         } bits;
         unsigned int value;
     } seq_fields;
-    unsigned char num_slice_groups_minus1;
-    unsigned char slice_group_map_type;
-    unsigned short slice_group_change_rate_minus1;
+    // FMO is not supported.
+    va_deprecated unsigned char num_slice_groups_minus1;
+    va_deprecated unsigned char slice_group_map_type;
+    va_deprecated unsigned short slice_group_change_rate_minus1;
     signed char pic_init_qp_minus26;
     signed char pic_init_qs_minus26;
     signed char chroma_qp_index_offset;
@@ -2025,16 +2026,6 @@ typedef struct _VAIQMatrixBufferH264
     /** \brief 8x8 scaling list, in raster scan order. */
     unsigned char ScalingList8x8[2][64];
 } VAIQMatrixBufferH264;
-
-/**
- * H.264 Slice Group Map Buffer 
- * When VAPictureParameterBufferH264::num_slice_group_minus1 is not equal to 0,
- * A slice group map buffer should be sent for each picture if required. The buffer
- * is sent only when there is a change in the mapping values.
- * The slice group map buffer map "map units" to slice groups as specified in 
- * section 8.2.2 of the H.264 spec. The buffer will contain one byte for each macroblock 
- * in raster scan order
- */ 
 
 /** H.264 Slice Parameter Buffer */
 typedef struct _VASliceParameterBufferH264

--- a/va/va_backend.h
+++ b/va/va_backend.h
@@ -553,6 +553,11 @@ struct VADisplayContext
     void *opaque; /* opaque for display extensions (e.g. GLX) */
     void *vatrace; /* opaque for VA trace context */
     void *vafool; /* opaque for VA fool context */
+
+    VAMessageCallback error_callback;
+    void *error_callback_user_context;
+    VAMessageCallback info_callback;
+    void *info_callback_user_context;
 };
 
 typedef VAStatus (*VADriverInit) (

--- a/va/va_fool.c
+++ b/va/va_fool.c
@@ -26,6 +26,7 @@
 #include "sysdeps.h"
 #include "va.h"
 #include "va_backend.h"
+#include "va_internal.h"
 #include "va_trace.h"
 #include "va_fool.h"
 
@@ -102,12 +103,6 @@ struct fool_context {
     if ((fool_ctx == NULL) || (fool_ctx->enabled == 0))  \
         return 0; /* no fool for the context */          \
 
-/* Prototype declarations (functions defined in va.c) */
-
-void va_errorMessage(const char *msg, ...);
-void va_infoMessage(const char *msg, ...);
-
-int  va_parseConfig(char *env, char *env_value);
 
 void va_FoolInit(VADisplay dpy)
 {

--- a/va/va_fool.c
+++ b/va/va_fool.c
@@ -62,14 +62,14 @@
 
 
 /* global settings */
-int fool_codec = 0;
-int fool_postp  = 0;
+int va_fool_codec = 0;
+int va_fool_postp  = 0;
 
 #define FOOL_BUFID_MAGIC   0x12345600
 #define FOOL_BUFID_MASK    0xffffff00
 
 struct fool_context {
-    int enabled; /* fool_codec is global, and it is for concurent encode/decode */
+    int enabled; /* va_fool_codec is global, and it is for concurent encode/decode */
     char *fn_enc;/* file pattern with codedbuf content for encode */
     char *segbuf_enc; /* the segment buffer of coded buffer, load frome fn_enc */
     int file_count;
@@ -114,22 +114,22 @@ void va_FoolInit(VADisplay dpy)
         return;
     
     if (va_parseConfig("LIBVA_FOOL_POSTP", NULL) == 0) {
-        fool_postp = 1;
+        va_fool_postp = 1;
         va_infoMessage(dpy, "LIBVA_FOOL_POSTP is on, dummy vaPutSurface\n");
     }
     
     if (va_parseConfig("LIBVA_FOOL_DECODE", NULL) == 0) {
-        fool_codec  |= VA_FOOL_FLAG_DECODE;
+        va_fool_codec  |= VA_FOOL_FLAG_DECODE;
         va_infoMessage(dpy, "LIBVA_FOOL_DECODE is on, dummy decode\n");
     }
     if (va_parseConfig("LIBVA_FOOL_ENCODE", &env_value[0]) == 0) {
-        fool_codec  |= VA_FOOL_FLAG_ENCODE;
+        va_fool_codec  |= VA_FOOL_FLAG_ENCODE;
         fool_ctx->fn_enc = strdup(env_value);
         va_infoMessage(dpy, "LIBVA_FOOL_ENCODE is on, load encode data from file with patten %s\n",
                        fool_ctx->fn_enc);
     }
     if (va_parseConfig("LIBVA_FOOL_JPEG", &env_value[0]) == 0) {
-        fool_codec  |= VA_FOOL_FLAG_JPEG;
+        va_fool_codec  |= VA_FOOL_FLAG_JPEG;
         fool_ctx->fn_jpg = strdup(env_value);
         va_infoMessage(dpy, "LIBVA_FOOL_JPEG is on, load encode data from file with patten %s\n",
                        fool_ctx->fn_jpg);
@@ -177,15 +177,15 @@ int va_FoolCreateConfig(
     fool_ctx->entrypoint = entrypoint;
     
     /*
-     * check fool_codec to align with current context
-     * e.g. fool_codec = decode then for encode, the
+     * check va_fool_codec to align with current context
+     * e.g. va_fool_codec = decode then for encode, the
      * vaBegin/vaRender/vaEnd also run into fool path
      * which is not desired
      */
-    if (((fool_codec & VA_FOOL_FLAG_DECODE) && (entrypoint == VAEntrypointVLD)) ||
-        ((fool_codec & VA_FOOL_FLAG_JPEG) && (entrypoint == VAEntrypointEncPicture)))
+    if (((va_fool_codec & VA_FOOL_FLAG_DECODE) && (entrypoint == VAEntrypointVLD)) ||
+        ((va_fool_codec & VA_FOOL_FLAG_JPEG) && (entrypoint == VAEntrypointEncPicture)))
         fool_ctx->enabled = 1;
-    else if ((fool_codec & VA_FOOL_FLAG_ENCODE) && (entrypoint == VAEntrypointEncSlice)) {
+    else if ((va_fool_codec & VA_FOOL_FLAG_ENCODE) && (entrypoint == VAEntrypointEncSlice)) {
         /* H264 is desired */
         if (((profile == VAProfileH264Baseline ||
               profile == VAProfileH264Main ||

--- a/va/va_fool.c
+++ b/va/va_fool.c
@@ -115,23 +115,23 @@ void va_FoolInit(VADisplay dpy)
     
     if (va_parseConfig("LIBVA_FOOL_POSTP", NULL) == 0) {
         fool_postp = 1;
-        va_infoMessage("LIBVA_FOOL_POSTP is on, dummy vaPutSurface\n");
+        va_infoMessage(dpy, "LIBVA_FOOL_POSTP is on, dummy vaPutSurface\n");
     }
     
     if (va_parseConfig("LIBVA_FOOL_DECODE", NULL) == 0) {
         fool_codec  |= VA_FOOL_FLAG_DECODE;
-        va_infoMessage("LIBVA_FOOL_DECODE is on, dummy decode\n");
+        va_infoMessage(dpy, "LIBVA_FOOL_DECODE is on, dummy decode\n");
     }
     if (va_parseConfig("LIBVA_FOOL_ENCODE", &env_value[0]) == 0) {
         fool_codec  |= VA_FOOL_FLAG_ENCODE;
         fool_ctx->fn_enc = strdup(env_value);
-        va_infoMessage("LIBVA_FOOL_ENCODE is on, load encode data from file with patten %s\n",
+        va_infoMessage(dpy, "LIBVA_FOOL_ENCODE is on, load encode data from file with patten %s\n",
                        fool_ctx->fn_enc);
     }
     if (va_parseConfig("LIBVA_FOOL_JPEG", &env_value[0]) == 0) {
         fool_codec  |= VA_FOOL_FLAG_JPEG;
         fool_ctx->fn_jpg = strdup(env_value);
-        va_infoMessage("LIBVA_FOOL_JPEG is on, load encode data from file with patten %s\n",
+        va_infoMessage(dpy, "LIBVA_FOOL_JPEG is on, load encode data from file with patten %s\n",
                        fool_ctx->fn_jpg);
     }
     
@@ -200,9 +200,9 @@ int va_FoolCreateConfig(
             fool_ctx->enabled = 1;
     }
     if (fool_ctx->enabled)
-        va_infoMessage("FOOL is enabled for this context\n");
+        va_infoMessage(dpy, "FOOL is enabled for this context\n");
     else
-        va_infoMessage("FOOL is not enabled for this context\n");
+        va_infoMessage(dpy, "FOOL is not enabled for this context\n");
 
     
     return 0; /* continue */

--- a/va/va_fool.c
+++ b/va/va_fool.c
@@ -269,6 +269,7 @@ static int va_FoolFillCodedBufEnc(struct fool_context *fool_ctx)
     struct stat file_stat = {0};
     VACodedBufferSegment *codedbuf;
     int i, fd = -1;
+    ssize_t ret;
 
     /* try file_name.file_count, if fail, try file_name.file_count-- */
     for (i=0; i<=1; i++) {
@@ -285,7 +286,9 @@ static int va_FoolFillCodedBufEnc(struct fool_context *fool_ctx)
     }
     if (fd != -1) {
         fool_ctx->segbuf_enc = realloc(fool_ctx->segbuf_enc, file_stat.st_size);
-        read(fd, fool_ctx->segbuf_enc, file_stat.st_size);
+        ret = read(fd, fool_ctx->segbuf_enc, file_stat.st_size);
+        if (ret < file_stat.st_size)
+            va_errorMessage("Reading file %s failed.\n", file_name);
         close(fd);
     } else
         va_errorMessage("Open file %s failed:%s\n", file_name, strerror(errno));
@@ -306,11 +309,14 @@ static int va_FoolFillCodedBufJPG(struct fool_context *fool_ctx)
     struct stat file_stat = {0};
     VACodedBufferSegment *codedbuf;
     int fd = -1;
+    ssize_t ret;
 
     if ((fd = open(fool_ctx->fn_jpg, O_RDONLY)) != -1) {
         fstat(fd, &file_stat);
         fool_ctx->segbuf_jpg = realloc(fool_ctx->segbuf_jpg, file_stat.st_size);
-        read(fd, fool_ctx->segbuf_jpg, file_stat.st_size);
+        ret = read(fd, fool_ctx->segbuf_jpg, file_stat.st_size);
+        if (ret < file_stat.st_size)
+            va_errorMessage("Reading file %s failed.\n", fool_ctx->fn_jpg);
         close(fd);
     } else
         va_errorMessage("Open file %s failed:%s\n", fool_ctx->fn_jpg, strerror(errno));

--- a/va/va_fool.h
+++ b/va/va_fool.h
@@ -32,15 +32,15 @@
 extern "C" {
 #endif
 
-extern int fool_codec;
-extern int fool_postp;
+extern int va_fool_codec;
+extern int va_fool_postp;
 
 #define VA_FOOL_FLAG_DECODE  0x1
 #define VA_FOOL_FLAG_ENCODE  0x2
 #define VA_FOOL_FLAG_JPEG    0x4
 
 #define VA_FOOL_FUNC(fool_func,...)            \
-    if (fool_codec) {                          \
+    if (va_fool_codec) {                       \
         if (fool_func(__VA_ARGS__))            \
             return VA_STATUS_SUCCESS;          \
     }

--- a/va/va_internal.h
+++ b/va/va_internal.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017 Intel Corporation. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sub license, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the
+ * next paragraph) shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
+ * IN NO EVENT SHALL PRECISION INSIGHT AND/OR ITS SUPPLIERS BE LIABLE FOR
+ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef VA_INTERNAL_H
+#define VA_INTERNAL_H
+
+void va_errorMessage(const char *msg, ...);
+void va_infoMessage(const char *msg, ...);
+
+int  va_parseConfig(char *env, char *env_value);
+
+#endif /* VA_INTERNAL_H */

--- a/va/va_internal.h
+++ b/va/va_internal.h
@@ -25,6 +25,9 @@
 #ifndef VA_INTERNAL_H
 #define VA_INTERNAL_H
 
+#define CTX(dpy) (((VADisplayContextP)dpy)->pDriverContext)
+#define CHECK_DISPLAY(dpy) if( !vaDisplayIsValid(dpy) ) { return VA_STATUS_ERROR_INVALID_DISPLAY; }
+
 void va_errorMessage(const char *msg, ...);
 void va_infoMessage(const char *msg, ...);
 

--- a/va/va_internal.h
+++ b/va/va_internal.h
@@ -28,8 +28,8 @@
 #define CTX(dpy) (((VADisplayContextP)dpy)->pDriverContext)
 #define CHECK_DISPLAY(dpy) if( !vaDisplayIsValid(dpy) ) { return VA_STATUS_ERROR_INVALID_DISPLAY; }
 
-void va_errorMessage(const char *msg, ...);
-void va_infoMessage(const char *msg, ...);
+void va_errorMessage(VADisplay dpy, const char *msg, ...);
+void va_infoMessage(VADisplay dpy, const char *msg, ...);
 
 int  va_parseConfig(char *env, char *env_value);
 

--- a/va/va_internal.h
+++ b/va/va_internal.h
@@ -33,4 +33,6 @@ void va_infoMessage(const char *msg, ...);
 
 int  va_parseConfig(char *env, char *env_value);
 
+VADisplayContextP va_newDisplayContext(void);
+
 #endif /* VA_INTERNAL_H */

--- a/va/va_tpi.c
+++ b/va/va_tpi.c
@@ -27,6 +27,7 @@
 #include "va.h"
 #include "va_backend.h"
 #include "va_backend_tpi.h"
+#include "va_internal.h"
 
 #include <assert.h>
 #include <stdarg.h>
@@ -35,9 +36,6 @@
 #include <string.h>
 #include <dlfcn.h>
 #include <unistd.h>
-
-#define CTX(dpy) (((VADisplayContextP)dpy)->pDriverContext)
-#define CHECK_DISPLAY(dpy) if( !vaDisplayIsValid(dpy) ) { return VA_STATUS_ERROR_INVALID_DISPLAY; }
 
 
 /*

--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -28,6 +28,7 @@
 #include "va.h"
 #include "va_enc_h264.h"
 #include "va_backend.h"
+#include "va_internal.h"
 #include "va_trace.h"
 #include "va_enc_h264.h"
 #include "va_enc_jpeg.h"
@@ -233,12 +234,6 @@ struct va_trace {
     va_TraceMsg(trace_ctx, "") ; \
 } while (0)
 
-/* Prototype declarations (functions defined in va.c) */
-
-void va_errorMessage(const char *msg, ...);
-void va_infoMessage(const char *msg, ...);
-
-int va_parseConfig(char *env, char *env_value);
 
 VAStatus vaBufferInfo(
     VADisplay dpy,

--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -67,7 +67,7 @@
 /* global settings */
 
 /* LIBVA_TRACE */
-int trace_flag = 0;
+int va_trace_flag = 0;
 
 #define MAX_TRACE_CTX_NUM   64
 #define TRACE_CTX_ID_MASK      (MAX_TRACE_CTX_NUM - 1)
@@ -747,7 +747,7 @@ void va_TraceInit(VADisplay dpy)
         trace_ctx->plog_file = start_tracing2log_file(pva_trace);
         if(trace_ctx->plog_file) {
             trace_ctx->plog_file_list[0] = trace_ctx->plog_file;
-            trace_flag = VA_TRACE_FLAG_LOG;
+            va_trace_flag = VA_TRACE_FLAG_LOG;
 
             va_infoMessage("LIBVA_TRACE is on, save log into %s\n",
                 trace_ctx->plog_file->fn_log);
@@ -757,8 +757,8 @@ void va_TraceInit(VADisplay dpy)
     }
 
     /* may re-get the global settings for multiple context */
-    if ((trace_flag & VA_TRACE_FLAG_LOG) && (va_parseConfig("LIBVA_TRACE_BUFDATA", NULL) == 0)) {
-        trace_flag |= VA_TRACE_FLAG_BUFDATA;
+    if ((va_trace_flag & VA_TRACE_FLAG_LOG) && (va_parseConfig("LIBVA_TRACE_BUFDATA", NULL) == 0)) {
+        va_trace_flag |= VA_TRACE_FLAG_BUFDATA;
 
         va_infoMessage(dpy, "LIBVA_TRACE_BUFDATA is on, dump buffer into log file\n");
     }
@@ -766,7 +766,7 @@ void va_TraceInit(VADisplay dpy)
     /* per-context setting */
     if (va_parseConfig("LIBVA_TRACE_CODEDBUF", &env_value[0]) == 0) {
         pva_trace->fn_codedbuf_env = strdup(env_value);
-        trace_flag |= VA_TRACE_FLAG_CODEDBUF;
+        va_trace_flag |= VA_TRACE_FLAG_CODEDBUF;
     }
 
     if (va_parseConfig("LIBVA_TRACE_SURFACE", &env_value[0]) == 0) {
@@ -779,11 +779,11 @@ void va_TraceInit(VADisplay dpy)
          * if no dec/enc in file name, set both
          */
         if (strstr(env_value, "dec"))
-            trace_flag |= VA_TRACE_FLAG_SURFACE_DECODE;
+            va_trace_flag |= VA_TRACE_FLAG_SURFACE_DECODE;
         if (strstr(env_value, "enc"))
-            trace_flag |= VA_TRACE_FLAG_SURFACE_ENCODE;
+            va_trace_flag |= VA_TRACE_FLAG_SURFACE_ENCODE;
         if (strstr(env_value, "jpeg") || strstr(env_value, "jpg"))
-            trace_flag |= VA_TRACE_FLAG_SURFACE_JPEG;
+            va_trace_flag |= VA_TRACE_FLAG_SURFACE_JPEG;
 
         if (va_parseConfig("LIBVA_TRACE_SURFACE_GEOMETRY", &env_value[0]) == 0) {
             char *p = env_value, *q;
@@ -813,7 +813,7 @@ void va_TraceInit(VADisplay dpy)
     ((VADisplayContextP)dpy)->vatrace = (void *)pva_trace;
     pva_trace->dpy = dpy;
 
-    if(!trace_flag)
+    if(!va_trace_flag)
         va_TraceEnd(dpy);
 }
 
@@ -891,7 +891,7 @@ static void va_TraceVPrint(struct trace_context *trace_ctx, const char *msg, va_
 {
     FILE *fp = NULL;
 
-    if (!(trace_flag & VA_TRACE_FLAG_LOG)
+    if (!(va_trace_flag & VA_TRACE_FLAG_LOG)
         || !trace_ctx->plog_file)
         return;
 
@@ -1328,7 +1328,7 @@ void va_TraceCreateContext(
     trace_ctx->trace_profile = pva_trace->config_info[i].trace_profile;
     trace_ctx->trace_entrypoint = pva_trace->config_info[i].trace_entrypoint;
 
-    if(trace_flag & VA_TRACE_FLAG_LOG) {
+    if(va_trace_flag & VA_TRACE_FLAG_LOG) {
         trace_ctx->plog_file = start_tracing2log_file(pva_trace);
         if(!trace_ctx->plog_file) {
             va_errorMessage(dpy, "Can't get trace log file for ctx 0x%08x\n",
@@ -1345,7 +1345,7 @@ void va_TraceCreateContext(
 
     trace_ctx->trace_context = *context;
     TRACE_FUNCNAME(idx);
-    va_TraceMsg(trace_ctx, "\tcontext = 0x%08x trace_flag 0x%x\n", *context, trace_flag);
+    va_TraceMsg(trace_ctx, "\tcontext = 0x%08x va_trace_flag 0x%x\n", *context, va_trace_flag);
     va_TraceMsg(trace_ctx, "\tprofile = %d entrypoint = %d\n", trace_ctx->trace_profile,
         trace_ctx->trace_entrypoint);
     va_TraceMsg(trace_ctx, "\tconfig = 0x%08x\n", config_id);
@@ -1373,21 +1373,21 @@ void va_TraceCreateContext(
     encode = (trace_ctx->trace_entrypoint == VAEntrypointEncSlice);
     decode = (trace_ctx->trace_entrypoint == VAEntrypointVLD);
     jpeg = (trace_ctx->trace_entrypoint == VAEntrypointEncPicture);
-    if ((encode && (trace_flag & VA_TRACE_FLAG_SURFACE_ENCODE)) ||
-        (decode && (trace_flag & VA_TRACE_FLAG_SURFACE_DECODE)) ||
-        (jpeg && (trace_flag & VA_TRACE_FLAG_SURFACE_JPEG))) {
+    if ((encode && (va_trace_flag & VA_TRACE_FLAG_SURFACE_ENCODE)) ||
+        (decode && (va_trace_flag & VA_TRACE_FLAG_SURFACE_DECODE)) ||
+        (jpeg && (va_trace_flag & VA_TRACE_FLAG_SURFACE_JPEG))) {
         if(open_tracing_specil_file(pva_trace, trace_ctx, 1) < 0) {
             va_errorMessage(dpy, "Open surface fail failed for ctx 0x%08x\n", *context);
 
-            trace_flag &= ~(VA_TRACE_FLAG_SURFACE);
+            va_trace_flag &= ~(VA_TRACE_FLAG_SURFACE);
         }
     }
 
-    if (encode && (trace_flag & VA_TRACE_FLAG_CODEDBUF)) {
+    if (encode && (va_trace_flag & VA_TRACE_FLAG_CODEDBUF)) {
         if(open_tracing_specil_file(pva_trace, trace_ctx, 0) < 0) {
             va_errorMessage(dpy, "Open codedbuf fail failed for ctx 0x%08x\n", *context);
 
-            trace_flag &= ~(VA_TRACE_FLAG_CODEDBUF);
+            va_trace_flag &= ~(VA_TRACE_FLAG_CODEDBUF);
         }
     }
 
@@ -1660,7 +1660,7 @@ static void va_TraceVABuffers(
     if(trace_ctx->plog_file)
         fp = trace_ctx->plog_file->fp_log;
 
-    if ((trace_flag & VA_TRACE_FLAG_BUFDATA) && fp) {
+    if ((va_trace_flag & VA_TRACE_FLAG_BUFDATA) && fp) {
         for (i=0; i<size; i++) {
             unsigned char value =  p[i];
 
@@ -4881,12 +4881,12 @@ void va_TraceEndPicture(
     jpeg = (trace_ctx->trace_entrypoint == VAEntrypointEncPicture);
 
     /* trace encode source surface, can do it before HW completes rendering */
-    if ((encode && (trace_flag & VA_TRACE_FLAG_SURFACE_ENCODE))||
-        (jpeg && (trace_flag & VA_TRACE_FLAG_SURFACE_JPEG)))
+    if ((encode && (va_trace_flag & VA_TRACE_FLAG_SURFACE_ENCODE))||
+        (jpeg && (va_trace_flag & VA_TRACE_FLAG_SURFACE_JPEG)))
         va_TraceSurface(dpy, context);
     
     /* trace decoded surface, do it after HW completes rendering */
-    if (decode && ((trace_flag & VA_TRACE_FLAG_SURFACE_DECODE))) {
+    if (decode && ((va_trace_flag & VA_TRACE_FLAG_SURFACE_DECODE))) {
         vaSyncSurface(dpy, trace_ctx->trace_rendertarget);
         va_TraceSurface(dpy, context);
     }

--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -2672,9 +2672,6 @@ static void va_TraceVAPictureParameterBufferH264(
     va_TraceMsg(trace_ctx, "\tmb_adaptive_frame_field_flag = %d\n", p->seq_fields.bits.mb_adaptive_frame_field_flag);
     va_TraceMsg(trace_ctx, "\tdirect_8x8_inference_flag = %d\n", p->seq_fields.bits.direct_8x8_inference_flag);
     va_TraceMsg(trace_ctx, "\tMinLumaBiPredSize8x8 = %d\n", p->seq_fields.bits.MinLumaBiPredSize8x8);
-    va_TraceMsg(trace_ctx, "\tnum_slice_groups_minus1 = %d\n", p->num_slice_groups_minus1);
-    va_TraceMsg(trace_ctx, "\tslice_group_map_type = %d\n", p->slice_group_map_type);
-    va_TraceMsg(trace_ctx, "\tslice_group_change_rate_minus1 = %d\n", p->slice_group_change_rate_minus1);
     va_TraceMsg(trace_ctx, "\tpic_init_qp_minus26 = %d\n", p->pic_init_qp_minus26);
     va_TraceMsg(trace_ctx, "\tpic_init_qs_minus26 = %d\n", p->pic_init_qs_minus26);
     va_TraceMsg(trace_ctx, "\tchroma_qp_index_offset = %d\n", p->chroma_qp_index_offset);

--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -162,6 +162,7 @@ struct va_trace {
 
     pthread_mutex_t resource_mutex;
     pthread_mutex_t context_mutex;
+    VADisplay dpy;
 };
 
 #define LOCK_RESOURCE(pva_trace)                                    \
@@ -392,7 +393,7 @@ static void add_trace_buf_info(
     }
 
     if(i >= MAX_TRACE_BUF_INFO_HASH_LEVEL)
-        va_errorMessage("Add buf info failed\n");
+        va_errorMessage(pva_trace->dpy, "Add buf info failed\n");
 
     UNLOCK_RESOURCE(pva_trace);
 }
@@ -581,7 +582,7 @@ static int open_tracing_log_file(
     int new_fn_flag = 0;
 
     if(plog_file->used && plog_file->thread_id != thd_id) {
-        va_errorMessage("Try to open a busy log file occupied by other thread\n");
+        va_errorMessage(pva_trace->dpy, "Try to open a busy log file occupied by other thread\n");
 
         return -1;
     }
@@ -759,7 +760,7 @@ void va_TraceInit(VADisplay dpy)
     if ((trace_flag & VA_TRACE_FLAG_LOG) && (va_parseConfig("LIBVA_TRACE_BUFDATA", NULL) == 0)) {
         trace_flag |= VA_TRACE_FLAG_BUFDATA;
 
-        va_infoMessage("LIBVA_TRACE_BUFDATA is on, dump buffer into log file\n");
+        va_infoMessage(dpy, "LIBVA_TRACE_BUFDATA is on, dump buffer into log file\n");
     }
 
     /* per-context setting */
@@ -795,7 +796,7 @@ void va_TraceInit(VADisplay dpy)
             p = q+1; /* skip "+" */
             trace_ctx->trace_surface_yoff = strtod(p, &q);
 
-            va_infoMessage("LIBVA_TRACE_SURFACE_GEOMETRY is on, only dump surface %dx%d+%d+%d content\n",
+            va_infoMessage(dpy, "LIBVA_TRACE_SURFACE_GEOMETRY is on, only dump surface %dx%d+%d+%d content\n",
                            trace_ctx->trace_surface_width,
                            trace_ctx->trace_surface_height,
                            trace_ctx->trace_surface_xoff,
@@ -810,6 +811,7 @@ void va_TraceInit(VADisplay dpy)
     pva_trace->ptra_ctx[MAX_TRACE_CTX_NUM] = trace_ctx;
 
     ((VADisplayContextP)dpy)->vatrace = (void *)pva_trace;
+    pva_trace->dpy = dpy;
 
     if(!trace_flag)
         va_TraceEnd(dpy);
@@ -1293,7 +1295,7 @@ void va_TraceCreateContext(
     if(!context
         || *context == VA_INVALID_ID
         || !pva_trace) {
-        va_errorMessage("Invalid context id 0x%08x\n",
+        va_errorMessage(dpy, "Invalid context id 0x%08x\n",
                 context == NULL ? 0 : (int)*context);
         return;
     }
@@ -1302,7 +1304,7 @@ void va_TraceCreateContext(
 
     tra_ctx_id = get_free_ctx_idx(pva_trace, *context);
     if(tra_ctx_id >= MAX_TRACE_CTX_NUM) {
-        va_errorMessage("Can't get trace context for ctx 0x%08x\n",
+        va_errorMessage(dpy, "Can't get trace context for ctx 0x%08x\n",
                 *context);
         
         goto FAIL;
@@ -1310,7 +1312,7 @@ void va_TraceCreateContext(
 
     trace_ctx = calloc(sizeof(struct trace_context), 1);
     if(trace_ctx == NULL) {
-        va_errorMessage("Allocate trace context failed for ctx 0x%08x\n",
+        va_errorMessage(dpy, "Allocate trace context failed for ctx 0x%08x\n",
                 *context);
         
         goto FAIL;
@@ -1318,7 +1320,7 @@ void va_TraceCreateContext(
 
     i = get_valid_config_idx(pva_trace, config_id);
     if(i >= MAX_TRACE_CTX_NUM) {
-        va_errorMessage("Can't get trace config id for ctx 0x%08x cfg %x\n",
+        va_errorMessage(dpy, "Can't get trace config id for ctx 0x%08x cfg %x\n",
                 *context, config_id);
 
         goto FAIL;
@@ -1329,13 +1331,13 @@ void va_TraceCreateContext(
     if(trace_flag & VA_TRACE_FLAG_LOG) {
         trace_ctx->plog_file = start_tracing2log_file(pva_trace);
         if(!trace_ctx->plog_file) {
-            va_errorMessage("Can't get trace log file for ctx 0x%08x\n",
+            va_errorMessage(dpy, "Can't get trace log file for ctx 0x%08x\n",
                     *context);
 
             goto FAIL;
         }
         else
-            va_infoMessage("Save context 0x%08x into log file %s\n", *context,
+            va_infoMessage(dpy, "Save context 0x%08x into log file %s\n", *context,
                 trace_ctx->plog_file->fn_log);
 
         trace_ctx->plog_file_list[0] = trace_ctx->plog_file;
@@ -1375,7 +1377,7 @@ void va_TraceCreateContext(
         (decode && (trace_flag & VA_TRACE_FLAG_SURFACE_DECODE)) ||
         (jpeg && (trace_flag & VA_TRACE_FLAG_SURFACE_JPEG))) {
         if(open_tracing_specil_file(pva_trace, trace_ctx, 1) < 0) {
-            va_errorMessage("Open surface fail failed for ctx 0x%08x\n", *context);
+            va_errorMessage(dpy, "Open surface fail failed for ctx 0x%08x\n", *context);
 
             trace_flag &= ~(VA_TRACE_FLAG_SURFACE);
         }
@@ -1383,7 +1385,7 @@ void va_TraceCreateContext(
 
     if (encode && (trace_flag & VA_TRACE_FLAG_CODEDBUF)) {
         if(open_tracing_specil_file(pva_trace, trace_ctx, 0) < 0) {
-            va_errorMessage("Open codedbuf fail failed for ctx 0x%08x\n", *context);
+            va_errorMessage(dpy, "Open codedbuf fail failed for ctx 0x%08x\n", *context);
 
             trace_flag &= ~(VA_TRACE_FLAG_CODEDBUF);
         }

--- a/va/va_trace.h
+++ b/va/va_trace.h
@@ -29,7 +29,7 @@
 extern "C" {
 #endif
 
-extern int trace_flag;
+extern int va_trace_flag;
 
 #define VA_TRACE_FLAG_LOG             0x1
 #define VA_TRACE_FLAG_BUFDATA         0x2
@@ -42,11 +42,11 @@ extern int trace_flag;
                                        VA_TRACE_FLAG_SURFACE_JPEG)
 
 #define VA_TRACE_LOG(trace_func,...)            \
-    if (trace_flag & VA_TRACE_FLAG_LOG) {       \
+    if (va_trace_flag & VA_TRACE_FLAG_LOG) {    \
         trace_func(__VA_ARGS__);                \
     }
 #define VA_TRACE_ALL(trace_func,...)            \
-    if (trace_flag) {                           \
+    if (va_trace_flag) {                        \
         trace_func(__VA_ARGS__);                \
     }
 

--- a/va/wayland/va_wayland.c
+++ b/va/wayland/va_wayland.c
@@ -32,6 +32,7 @@
 #include "va_wayland_private.h"
 #include "va_backend.h"
 #include "va_backend_wayland.h"
+#include "va_internal.h"
 
 static inline VADriverContextP
 get_driver_context(VADisplay dpy)
@@ -120,11 +121,10 @@ vaGetDisplayWl(struct wl_display *display)
     struct VADriverVTableWayland *vtable;
     unsigned int i;
 
-    pDisplayContext = calloc(1, sizeof(*pDisplayContext));
+    pDisplayContext = va_newDisplayContext();
     if (!pDisplayContext)
         return NULL;
 
-    pDisplayContext->vadpy_magic        = VA_DISPLAY_MAGIC;
     pDisplayContext->vaIsValid          = va_DisplayContextIsValid;
     pDisplayContext->vaDestroy          = va_DisplayContextDestroy;
     pDisplayContext->vaGetDriverName    = va_DisplayContextGetDriverName;

--- a/va/x11/dri2_util.c
+++ b/va/x11/dri2_util.c
@@ -166,14 +166,14 @@ dri2Close(VADriverContextP ctx)
 {
     struct dri_state *dri_state = (struct dri_state *)ctx->drm_state;
 
-    free_drawable_hashtable(ctx);
+    va_dri_free_drawable_hashtable(ctx);
 
     if (dri_state->base.fd >= 0)
 	close(dri_state->base.fd);
 }
 
 Bool 
-isDRI2Connected(VADriverContextP ctx, char **driver_name)
+va_isDRI2Connected(VADriverContextP ctx, char **driver_name)
 {
     struct dri_state *dri_state = (struct dri_state *)ctx->drm_state;
     int major, minor;

--- a/va/x11/va_dricommon.c
+++ b/va/x11/va_dricommon.c
@@ -81,7 +81,7 @@ do_drawable_hash(VADriverContextP ctx, XID drawable)
 }
 
 void
-free_drawable(VADriverContextP ctx, struct dri_drawable* dri_drawable)
+va_dri_free_drawable(VADriverContextP ctx, struct dri_drawable* dri_drawable)
 {
     struct dri_state *dri_state = (struct dri_state *)ctx->drm_state;
     int i = 0;
@@ -96,7 +96,7 @@ free_drawable(VADriverContextP ctx, struct dri_drawable* dri_drawable)
 }
 
 void
-free_drawable_hashtable(VADriverContextP ctx)
+va_dri_free_drawable_hashtable(VADriverContextP ctx)
 {
     struct dri_state *dri_state = (struct dri_state *)ctx->drm_state;
     int i;
@@ -116,13 +116,13 @@ free_drawable_hashtable(VADriverContextP ctx)
 }
 
 struct dri_drawable *
-dri_get_drawable(VADriverContextP ctx, XID drawable)
+va_dri_get_drawable(VADriverContextP ctx, XID drawable)
 {
     return do_drawable_hash(ctx, drawable);
 }
 
 void 
-dri_swap_buffer(VADriverContextP ctx, struct dri_drawable *dri_drawable)
+va_dri_swap_buffer(VADriverContextP ctx, struct dri_drawable *dri_drawable)
 {
     struct dri_state *dri_state = (struct dri_state *)ctx->drm_state;
 
@@ -130,7 +130,7 @@ dri_swap_buffer(VADriverContextP ctx, struct dri_drawable *dri_drawable)
 }
 
 union dri_buffer *
-dri_get_rendering_buffer(VADriverContextP ctx, struct dri_drawable *dri_drawable)
+va_dri_get_rendering_buffer(VADriverContextP ctx, struct dri_drawable *dri_drawable)
 {
     struct dri_state *dri_state = (struct dri_state *)ctx->drm_state;
     

--- a/va/x11/va_dricommon.h
+++ b/va/x11/va_dricommon.h
@@ -84,11 +84,11 @@ struct dri_state
 #endif
 };
 
-Bool isDRI2Connected(VADriverContextP ctx, char **driver_name);
-void free_drawable(VADriverContextP ctx, struct dri_drawable* dri_drawable);
-void free_drawable_hashtable(VADriverContextP ctx);
-struct dri_drawable *dri_get_drawable(VADriverContextP ctx, XID drawable);
-void dri_swap_buffer(VADriverContextP ctx, struct dri_drawable *dri_drawable);
-union dri_buffer *dri_get_rendering_buffer(VADriverContextP ctx, struct dri_drawable *dri_drawable);
+Bool va_isDRI2Connected(VADriverContextP ctx, char **driver_name);
+void va_dri_free_drawable(VADriverContextP ctx, struct dri_drawable* dri_drawable);
+void va_dri_free_drawable_hashtable(VADriverContextP ctx);
+struct dri_drawable *va_dri_get_drawable(VADriverContextP ctx, XID drawable);
+void va_dri_swap_buffer(VADriverContextP ctx, struct dri_drawable *dri_drawable);
+union dri_buffer *va_dri_get_rendering_buffer(VADriverContextP ctx, struct dri_drawable *dri_drawable);
 
 #endif /* _VA_DRICOMMON_H_ */

--- a/va/x11/va_x11.c
+++ b/va/x11/va_x11.c
@@ -195,8 +195,6 @@ VADisplay vaGetDisplay (
   return dpy;
 }
 
-#define CTX(dpy) (((VADisplayContextP)dpy)->pDriverContext)
-#define CHECK_DISPLAY(dpy) if( !vaDisplayIsValid(dpy) ) { return VA_STATUS_ERROR_INVALID_DISPLAY; }
 
 void va_TracePutSurface (
     VADisplay dpy,

--- a/va/x11/va_x11.c
+++ b/va/x11/va_x11.c
@@ -81,7 +81,7 @@ static VAStatus va_DRI2GetDriverName (
 {
     VADriverContextP ctx = pDisplayContext->pDriverContext;
 
-    if (!isDRI2Connected(ctx, driver_name))
+    if (!va_isDRI2Connected(ctx, driver_name))
         return VA_STATUS_ERROR_UNKNOWN;
 
     return VA_STATUS_SUCCESS;

--- a/va/x11/va_x11.c
+++ b/va/x11/va_x11.c
@@ -26,6 +26,7 @@
 #include "sysdeps.h"
 #include "va.h"
 #include "va_backend.h"
+#include "va_internal.h"
 #include "va_trace.h"
 #include "va_fool.h"
 #include "va_x11.h"
@@ -163,13 +164,11 @@ VADisplay vaGetDisplay (
       /* create new entry */
       VADriverContextP pDriverContext;
       struct dri_state *dri_state;
-      pDisplayContext = calloc(1, sizeof(*pDisplayContext));
+      pDisplayContext = va_newDisplayContext();
       pDriverContext  = calloc(1, sizeof(*pDriverContext));
       dri_state       = calloc(1, sizeof(*dri_state));
       if (pDisplayContext && pDriverContext && dri_state)
       {
-	  pDisplayContext->vadpy_magic = VA_DISPLAY_MAGIC;          
-
 	  pDriverContext->native_dpy       = (void *)native_dpy;
 	  pDriverContext->x11_screen       = XDefaultScreen(native_dpy);
           pDriverContext->display_type     = VA_DISPLAY_X11;

--- a/va/x11/va_x11.c
+++ b/va/x11/va_x11.c
@@ -232,7 +232,7 @@ VAStatus vaPutSurface (
 {
   VADriverContextP ctx;
 
-  if (fool_postp)
+  if (va_fool_postp)
       return VA_STATUS_SUCCESS;
 
   CHECK_DISPLAY(dpy);


### PR DESCRIPTION
* Make logging callbacks usable in libraries - currently the global state only allows them to be used in end-user executables.
* Remove the H.264 FMO support which will never be used.
* Add namespace prefixes to globals which leak from the shared libraries.
* Some minor cleanup around all of that.

The Android parts aren't even build-tested (though hopefully that change was mechanical).