### PR TITLE
Add the suffix of '-2.0' to libva

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -51,28 +51,22 @@ m4_if(libva_pre_version, [0], [], [
 m4_append([libva_version], libva_pre_version, [.pre])
 ])
 
-# libva library version number (generated, do not change)
-# XXX: we want the SONAME to remain at libva.so.1 for VA-API major == 0
+# libva library name (generated, do not change)
 #
-# The library name is generated libva.<x>.<y>.0 where
+# The library name is generated libva-<x>.0.so.0.<y>.0 where
 # <x> = VA-API major version + 1
 # <y> = 100 * VA-API minor version + VA-API micro version
 #
 # For example:
-# VA-API 0.32.0 generates libva.so.1.3200.0
-# VA-API 0.34.1 generates libva.so.1.3401.0
-# VA-API 1.2.13 generates libva.so.2.213.0
-m4_define([libva_interface_bias], [m4_eval(va_api_major_version + 1)])
-m4_define([libva_interface_age],  [0])
-m4_define([libva_binary_age],
-          [m4_eval(100 * va_api_minor_version + va_api_micro_version - libva_interface_age)])
-
+# VA-API 1.0.0 generates libva-2.0.so.0.0.0
+# VA-API 1.0.1 generates libva-2.0.so.0.1.0
+# VA-API 1.1.1 generates libva-2.0.so.0.101.0
 m4_define([libva_lt_current],
-          [m4_eval(100 * va_api_minor_version + va_api_micro_version + libva_interface_bias)])
+          [m4_eval(100 * va_api_minor_version + va_api_micro_version)])
 m4_define([libva_lt_revision],
-          [m4_eval(libva_interface_age)])
+          [0])
 m4_define([libva_lt_age],
-          [m4_eval(libva_binary_age - libva_interface_age)])
+          [m4_eval(100 * va_api_micro_version + va_api_micro_version)])
 
 # libdrm minimun version requirement
 m4_define([libdrm_version], [2.4])
@@ -122,6 +116,13 @@ LIBVA_LT_VERSION="$LIBVA_LT_CURRENT:$LIBVA_LT_REV:$LIBVA_LT_AGE"
 LIBVA_LT_LDFLAGS="-version-info $LIBVA_LT_VERSION"
 AC_SUBST(LIBVA_LT_VERSION)
 AC_SUBST(LIBVA_LT_LDFLAGS)
+
+dnl our libraries and install dirs use LIBVA_LIB_VERSION in the filename
+dnl to allow side-by-side installation of different library versions
+LIBVA_LIB_VERSION=2.0
+AC_SUBST([LIBVA_LIB_VERSION])
+AC_DEFINE_UNQUOTED([LIBVA_LIB_VERSION], ["$LIBVA_LIB_VERSION"],
+  [Libva Library Version])
 
 AC_ARG_ENABLE(docs,
     [AC_HELP_STRING([--enable-docs],

--- a/pkgconfig/Makefile.am
+++ b/pkgconfig/Makefile.am
@@ -20,22 +20,22 @@
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-pcfiles		 = libva.pc
-pcfiles		+= libva-tpi.pc
+pcfiles		 = libva-@LIBVA_LIB_VERSION@.pc
+pcfiles		+= libva-tpi-@LIBVA_LIB_VERSION@.pc
 if USE_DRM
-pcfiles		+= libva-drm.pc
+pcfiles		+= libva-drm-@LIBVA_LIB_VERSION@.pc
 endif
 if USE_X11
-pcfiles		+= libva-x11.pc
+pcfiles		+= libva-x11-@LIBVA_LIB_VERSION@.pc
 endif
 if USE_GLX
-pcfiles		+= libva-glx.pc
+pcfiles		+= libva-glx-@LIBVA_LIB_VERSION@.pc
 endif
 if USE_EGL
-pcfiles		+= libva-egl.pc
+pcfiles		+= libva-egl-@LIBVA_LIB_VERSION@.pc
 endif
 if USE_WAYLAND
-pcfiles		+= libva-wayland.pc
+pcfiles		+= libva-wayland-@LIBVA_LIB_VERSION@.pc
 endif
 
 all_pcfiles_in	 = libva.pc.in
@@ -52,6 +52,10 @@ pkgconfig_DATA = $(pcfiles)
 EXTRA_DIST = $(all_pcfiles_in)
 
 DISTCLEANFILES = $(pcfiles)
+
+### how to generate pc files
+%-@LIBVA_LIB_VERSION@.pc: %.pc
+	@cp $< $@
 
 # Extra clean files so that maintainer-clean removes *everything*
 MAINTAINERCLEANFILES = Makefile.in

--- a/pkgconfig/libva-drm.pc.in
+++ b/pkgconfig/libva-drm.pc.in
@@ -1,12 +1,12 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir=@includedir@
+includedir=@includedir@-@LIBVA_LIB_VERSION@
 display=drm
 
 Name: libva-${display}
 Description: Userspace Video Acceleration (VA) ${display} interface
-Requires: libva
+Requires: libva-@LIBVA_LIB_VERSION@
 Version: @VA_API_VERSION@
-Libs: -L${libdir} -lva-${display}
+Libs: -L${libdir} -lva-${display}-@LIBVA_LIB_VERSION@
 Cflags: -I${includedir}

--- a/pkgconfig/libva-egl.pc.in
+++ b/pkgconfig/libva-egl.pc.in
@@ -1,13 +1,13 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir=@includedir@
+includedir=@includedir@-@LIBVA_LIB_VERSION@
 display=egl
 
 Name: libva-${display}
 Description: Userspace Video Acceleration (VA) ${display} interface
-Requires: libva
+Requires: libva-@LIBVA_LIB_VERSION@
 Version: @VA_API_VERSION@
-Libs: -L${libdir} -lva-${display}
+Libs: -L${libdir} -lva-${display}-@LIBVA_LIB_VERSION@
 Cflags: -I${includedir}
 

--- a/pkgconfig/libva-glx.pc.in
+++ b/pkgconfig/libva-glx.pc.in
@@ -1,12 +1,12 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir=@includedir@
+includedir=@includedir@-@LIBVA_LIB_VERSION@
 display=glx
 
 Name: libva-${display}
 Description: Userspace Video Acceleration (VA) ${display} interface
-Requires: libva
+Requires: libva-@LIBVA_LIB_VERSION@
 Version: @VA_API_VERSION@
-Libs: -L${libdir} -lva-${display}
+Libs: -L${libdir} -lva-${display}-@LIBVA_LIB_VERSION@
 Cflags: -I${includedir}

--- a/pkgconfig/libva-tpi.pc.in
+++ b/pkgconfig/libva-tpi.pc.in
@@ -1,11 +1,11 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir=@includedir@
+includedir=@includedir@-@LIBVA_LIB_VERSION@
 
 Name: libva-tpi
 Description: Userspace Video Acceleration (VA) 3rd party interface
-Requires: libva
+Requires: libva-@LIBVA_LIB_VERSION@
 Version: @VA_API_VERSION@
-Libs: -L${libdir} -lva-tpi
+Libs: -L${libdir} -lva-tpi-@LIBVA_LIB_VERSION@
 Cflags: -I${includedir}

--- a/pkgconfig/libva-wayland.pc.in
+++ b/pkgconfig/libva-wayland.pc.in
@@ -1,12 +1,12 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir=@includedir@
+includedir=@includedir@-@LIBVA_LIB_VERSION@
 display=wayland
 
 Name: libva-${display}
 Description: Userspace Video Acceleration (VA) ${display} interface
-Requires: libva wayland-client
+Requires: libva-@LIBVA_LIB_VERSION@ wayland-client
 Version: @VA_API_VERSION@
-Libs: -L${libdir} -lva-${display}
+Libs: -L${libdir} -lva-${display}-@LIBVA_LIB_VERSION@
 Cflags: -I${includedir}

--- a/pkgconfig/libva-x11.pc.in
+++ b/pkgconfig/libva-x11.pc.in
@@ -1,12 +1,12 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir=@includedir@
+includedir=@includedir@-@LIBVA_LIB_VERSION@
 display=x11
 
 Name: libva-${display}
 Description: Userspace Video Acceleration (VA) ${display} interface
-Requires: libva
+Requires: libva-@LIBVA_LIB_VERSION@
 Version: @VA_API_VERSION@
-Libs: -L${libdir} -lva-${display}
+Libs: -L${libdir} -lva-${display}-@LIBVA_LIB_VERSION@
 Cflags: -I${includedir}

--- a/pkgconfig/libva.pc.in
+++ b/pkgconfig/libva.pc.in
@@ -1,11 +1,11 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir=@includedir@
+includedir=@includedir@/va-@LIBVA_LIB_VERSION@
 driverdir=@LIBVA_DRIVERS_PATH@
 
 Name: libva
 Description: Userspace Video Acceleration (VA) core interface
 Version: @VA_API_VERSION@
-Libs: -L${libdir} -lva
+Libs: -L${libdir} -lva-@LIBVA_LIB_VERSION@
 Cflags: -I${includedir}

--- a/va/Makefile.am
+++ b/va/Makefile.am
@@ -69,69 +69,69 @@ libva_ldflags = \
 	-Wl,-version-script,${srcdir}/libva.syms \
 	$(NULL)
 
-lib_LTLIBRARIES			= libva.la
-libvaincludedir			= ${includedir}/va
-libvainclude_HEADERS		= $(libva_source_h)
-noinst_HEADERS			= $(libva_source_h_priv)
-libva_la_SOURCES		= $(libva_source_c)
-libva_la_LDFLAGS		= $(libva_ldflags)
-libva_la_DEPENDENCIES		= libva.syms
-libva_la_LIBADD			= $(LIBVA_LIBS) -ldl
+lib_LTLIBRARIES				= libva-@LIBVA_LIB_VERSION@.la
+libva_@LIBVA_LIB_VERSION@_includedir		= ${includedir}/va-@LIBVA_LIB_VERSION@/va
+libva_@LIBVA_LIB_VERSION@_include_HEADERS	= $(libva_source_h)
+noinst_HEADERS					= $(libva_source_h_priv)
+libva_@LIBVA_LIB_VERSION@_la_SOURCES		= $(libva_source_c)
+libva_@LIBVA_LIB_VERSION@_la_LDFLAGS		= $(libva_ldflags)
+libva_@LIBVA_LIB_VERSION@_la_DEPENDENCIES	= libva.syms
+libva_@LIBVA_LIB_VERSION@_la_LIBADD		= $(LIBVA_LIBS) -ldl
 
-lib_LTLIBRARIES			+= libva-tpi.la
-libva_tpi_la_SOURCES		= va_tpi.c
-libva_tpi_la_LDFLAGS		= $(LDADD) -no-undefined
-libva_tpi_la_DEPENDENCIES	= libva.la 
-libva_tpi_la_LIBADD		= libva.la -ldl
+lib_LTLIBRARIES				+= libva-tpi-@LIBVA_LIB_VERSION@.la
+libva_tpi_@LIBVA_LIB_VERSION@_la_SOURCES	= va_tpi.c
+libva_tpi_@LIBVA_LIB_VERSION@_la_LDFLAGS	= $(LDADD) -no-undefined
+libva_tpi_@LIBVA_LIB_VERSION@_la_DEPENDENCIES	= libva-@LIBVA_LIB_VERSION@.la
+libva_tpi_@LIBVA_LIB_VERSION@_la_LIBADD		= libva-@LIBVA_LIB_VERSION@.la -ldl
 
 if USE_DRM
 SUBDIRS				+= drm
-lib_LTLIBRARIES			+= libva-drm.la
-libva_drm_la_SOURCES		=
-libva_drm_la_LDFLAGS		= $(LDADD)
-libva_drm_la_DEPENDENCIES	= libva.la drm/libva_drm.la
-libva_drm_la_LIBADD		= libva.la drm/libva_drm.la \
+lib_LTLIBRARIES			+= libva-drm-@LIBVA_LIB_VERSION@.la
+libva_drm_@LIBVA_LIB_VERSION@_la_SOURCES	=
+libva_drm_@LIBVA_LIB_VERSION@_la_LDFLAGS	= $(LDADD)
+libva_drm_@LIBVA_LIB_VERSION@_la_DEPENDENCIES	= libva-@LIBVA_LIB_VERSION@.la drm/libva_drm.la
+libva_drm_@LIBVA_LIB_VERSION@_la_LIBADD		= libva-@LIBVA_LIB_VERSION@.la drm/libva_drm.la \
 	$(LIBVA_LIBS) $(DRM_LIBS) -ldl
 endif
 
 if USE_X11
 SUBDIRS				+= x11
-lib_LTLIBRARIES			+= libva-x11.la
-libva_source_h			+= va_x11.h
-libva_x11_la_SOURCES		= 
-libva_x11_la_LDFLAGS		= $(LDADD)
-libva_x11_la_DEPENDENCIES	= libva.la x11/libva_x11.la
-libva_x11_la_LIBADD		= libva.la x11/libva_x11.la \
+lib_LTLIBRARIES			+= libva-x11-@LIBVA_LIB_VERSION@.la
+libva_source_h					+= va_x11.h
+libva_x11_@LIBVA_LIB_VERSION@_la_SOURCES	=
+libva_x11_@LIBVA_LIB_VERSION@_la_LDFLAGS	= $(LDADD)
+libva_x11_@LIBVA_LIB_VERSION@_la_DEPENDENCIES	= libva-@LIBVA_LIB_VERSION@.la x11/libva_x11.la
+libva_x11_@LIBVA_LIB_VERSION@_la_LIBADD		= libva-@LIBVA_LIB_VERSION@.la x11/libva_x11.la \
 	$(LIBVA_LIBS) $(X11_LIBS) $(XEXT_LIBS) $(XFIXES_LIBS) $(DRM_LIBS) -ldl
 endif
 
 if USE_GLX
 SUBDIRS				+= glx
-lib_LTLIBRARIES			+= libva-glx.la
-libva_glx_la_SOURCES		=
-libva_glx_la_LDFLAGS		= $(LDADD)
-libva_glx_la_DEPENDENCIES	= libva.la glx/libva_glx.la libva-x11.la
-libva_glx_la_LIBADD		= libva.la glx/libva_glx.la libva-x11.la \
+lib_LTLIBRARIES			+= libva-glx-@LIBVA_LIB_VERSION@.la
+libva_glx_@LIBVA_LIB_VERSION@_la_SOURCES	=
+libva_glx_@LIBVA_LIB_VERSION@_la_LDFLAGS	= $(LDADD)
+libva_glx_@LIBVA_LIB_VERSION@_la_DEPENDENCIES	= libva-@LIBVA_LIB_VERSION@.la glx/libva_glx.la libva-x11-@LIBVA_LIB_VERSION@.la
+libva_glx_@LIBVA_LIB_VERSION@_la_LIBADD		= libva-@LIBVA_LIB_VERSION@.la glx/libva_glx.la libva-x11-@LIBVA_LIB_VERSION@.la \
 	$(GLX_LIBS) -ldl
 endif
 
 if USE_EGL
 SUBDIRS				+= egl
-lib_LTLIBRARIES			+= libva-egl.la
-libva_egl_la_SOURCES		=
-libva_egl_la_LDFLAGS		= $(LDADD)
-libva_egl_la_DEPENDENCIES	= libva.la egl/libva_egl.la 
-libva_egl_la_LIBADD		= libva.la egl/libva_egl.la \
+lib_LTLIBRARIES			+= libva-egl-@LIBVA_LIB_VERSION@.la
+libva_egl_@LIBVA_LIB_VERSION@_la_SOURCES	=
+libva_egl_@LIBVA_LIB_VERSION@_la_LDFLAGS	= $(LDADD)
+libva_egl_@LIBVA_LIB_VERSION@_la_DEPENDENCIES	= libva-@LIBVA_LIB_VERSION@.la egl/libva_egl.la
+libva_egl_@LIBVA_LIB_VERSION@_la_LIBADD		= libva-@LIBVA_LIB_VERSION@.la egl/libva_egl.la \
 	$(EGL_LIBS) -ldl
 endif
 
 if USE_WAYLAND
 SUBDIRS				+= wayland
-lib_LTLIBRARIES			+= libva-wayland.la
-libva_wayland_la_SOURCES	=
-libva_wayland_la_LDFLAGS	= $(LDADD)
-libva_wayland_la_DEPENDENCIES	= libva.la wayland/libva_wayland.la
-libva_wayland_la_LIBADD		= libva.la wayland/libva_wayland.la \
+lib_LTLIBRARIES			+= libva-wayland-@LIBVA_LIB_VERSION@.la
+libva_wayland_@LIBVA_LIB_VERSION@_la_SOURCES		=
+libva_wayland_@LIBVA_LIB_VERSION@_la_LDFLAGS		= $(LDADD)
+libva_wayland_@LIBVA_LIB_VERSION@_la_DEPENDENCIES	= libva-@LIBVA_LIB_VERSION@.la wayland/libva_wayland.la
+libva_wayland_@LIBVA_LIB_VERSION@_la_LIBADD		= libva-@LIBVA_LIB_VERSION@.la wayland/libva_wayland.la \
 	$(WAYLAND_LIBS) $(DRM_LIBS) -ldl
 endif
 

--- a/va/drm/Makefile.am
+++ b/va/drm/Makefile.am
@@ -49,7 +49,7 @@ AM_CPPFLAGS			+= $(X11_CFLAGS)
 endif
 
 noinst_LTLIBRARIES		= libva_drm.la
-libva_drmincludedir		= ${includedir}/va
+libva_drmincludedir		= ${includedir}/va-@LIBVA_LIB_VERSION@/va
 libva_drminclude_HEADERS	= $(source_h)
 libva_drm_la_SOURCES		= $(source_c)
 noinst_HEADERS			= $(source_h_priv)

--- a/va/egl/Makefile.am
+++ b/va/egl/Makefile.am
@@ -37,7 +37,7 @@ source_h = \
 source_h_priv = 
 
 noinst_LTLIBRARIES	 = libva_egl.la
-libva_eglincludedir	 = ${includedir}/va
+libva_eglincludedir	 = ${includedir}/va-@LIBVA_LIB_VERSION@/va
 libva_eglinclude_HEADERS = $(source_h)
 libva_egl_la_SOURCES	 = $(source_c)
 noinst_HEADERS		 = $(source_h_priv)

--- a/va/glx/Makefile.am
+++ b/va/glx/Makefile.am
@@ -45,7 +45,7 @@ source_h_priv = \
 	$(NULL)
 
 noinst_LTLIBRARIES		 = libva_glx.la
-libva_glxincludedir		 = ${includedir}/va
+libva_glxincludedir		 = ${includedir}/va-@LIBVA_LIB_VERSION@/va
 libva_glxinclude_HEADERS	 = $(source_h)
 libva_glx_la_SOURCES		 = $(source_c)
 noinst_HEADERS			 = $(source_h_priv)

--- a/va/va.c
+++ b/va/va.c
@@ -49,7 +49,7 @@
 #endif
 #endif
 
-#define DRIVER_EXTENSION	"_drv_video.so"
+#define DRIVER_EXTENSION	"_drv_video-2.0.so"
 
 #define ASSERT		assert
 #define CHECK_VTABLE(s, ctx, func) if (!va_checkVtable(dpy, ctx->vtable->va##func, #func)) s = VA_STATUS_ERROR_UNKNOWN;

--- a/va/wayland/Makefile.am
+++ b/va/wayland/Makefile.am
@@ -51,7 +51,7 @@ protocol_source_h = \
 	$(NULL)
 
 noinst_LTLIBRARIES		= libva_wayland.la
-libva_waylandincludedir		= ${includedir}/va
+libva_waylandincludedir		= ${includedir}/va-@LIBVA_LIB_VERSION@/va
 libva_waylandinclude_HEADERS	= $(source_h)
 libva_wayland_la_SOURCES	= $(source_c)
 noinst_HEADERS			= $(source_h_priv)

--- a/va/x11/Makefile.am
+++ b/va/x11/Makefile.am
@@ -52,7 +52,7 @@ source_h_priv = \
 	$(NULL)
 
 noinst_LTLIBRARIES		= libva_x11.la	
-libva_x11includedir		= ${includedir}/va
+libva_x11includedir		= ${includedir}/va-@LIBVA_LIB_VERSION@/va
 libva_x11include_HEADERS	= $(source_h)
 libva_x11_la_SOURCES		= $(source_c)
 noinst_HEADERS			= $(source_h_priv)


### PR DESCRIPTION
The corresponding library names are changed to libva-2.0.so,
libva-drm-2.0.so etc, the driver name is changed to
foo_drv_video-2.0.so etc. All includes files are installed
under ${prefix}/include/va-2.0/va. In this way, libva and
libva-2.0 can coexist in distributions for a transitional period
