### PR TITLE
va: Add the fourcc of I420 format

### DIFF
--- a/va/glx/va_glx_impl.c
+++ b/va/glx/va_glx_impl.c
@@ -205,7 +205,7 @@ static int check_extension3(const char *name)
     for(i = 0; i < nbExtensions; i++)
     {
         const GLubyte *strExtension = glGetStringi(GL_EXTENSIONS, i);
-        if(strcmp(strExtension, (const GLubyte *)name) == 0)
+        if(strcmp((const char *) strExtension, name) == 0)
             return 1;
     }
 

--- a/va/va.h
+++ b/va/va.h
@@ -589,7 +589,7 @@ typedef struct _VAConfigAttrib {
 #define VA_ENC_SLICE_STRUCTURE_ARBITRARY_ROWS           0x00000000
 /** \brief Driver supports a power-of-two number of rows per slice. */
 #define VA_ENC_SLICE_STRUCTURE_POWER_OF_TWO_ROWS        0x00000001
-/** \brief Driver supports an arbitrary number of rows per slice. */
+/** \brief Driver supports an arbitrary number of macroblocks per slice. */
 #define VA_ENC_SLICE_STRUCTURE_ARBITRARY_MACROBLOCKS    0x00000002
 /**@}*/
 

--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -340,7 +340,7 @@ static VAContextID get_ctx_by_buf(
     struct trace_buf_manager *pbuf_mgr = &pva_trace->buf_manager;
     struct trace_buf_info *pbuf_info = pbuf_mgr->pbuf_info[0];
     VAContextID context = VA_INVALID_ID;
-    int i = 0, idx = 0, valid = 0;
+    int i = 0, idx = 0;
 
     LOCK_RESOURCE(pva_trace);
 
@@ -734,8 +734,6 @@ static void refresh_log_file(
 void va_TraceInit(VADisplay dpy)
 {
     char env_value[1024];
-    unsigned short suffix = 0xffff & ((unsigned int)time(NULL));
-    FILE *tmp;
     struct va_trace *pva_trace = calloc(sizeof(struct va_trace), 1);
     struct trace_context *trace_ctx = calloc(sizeof(struct trace_context), 1);
 
@@ -823,7 +821,7 @@ void va_TraceInit(VADisplay dpy)
 void va_TraceEnd(VADisplay dpy)
 {
     struct va_trace *pva_trace = NULL;
-    int i = 0, j = 0;
+    int i = 0;
 
     pva_trace = (struct va_trace *)(((VADisplayContextP)dpy)->vatrace);
     if(!pva_trace)
@@ -3563,7 +3561,6 @@ static void va_TraceVAEncSequenceParameterBufferVP9(
 {
     VAEncSequenceParameterBufferVP9 *p = (VAEncSequenceParameterBufferVP9 *)data;
     DPY2TRACECTX(dpy, context, VA_INVALID_ID);
-    int i;
 
     va_TraceMsg(trace_ctx, "\t--VAEncSequenceParameterBufferVP9\n");
 


### PR DESCRIPTION
i965 will return the I420 in vaQuerySurfaceAttributes, but va.h didn't
add the pre-define fourcc

Signed-off-by: Jun Zhao <jun.zhao@intel.com>