### PR TITLE
add 2D buffer support

### DIFF
--- a/va/va.c
+++ b/va/va.c
@@ -1267,6 +1267,33 @@ VAStatus vaCreateBuffer (
   return vaStatus;
 }
 
+VAStatus vaCreateBuffer2 (
+    VADisplay dpy,
+    VAContextID context,
+    VABufferType type,
+    unsigned int width,
+    unsigned int height,
+    unsigned int *unit_size,
+    unsigned int *pitch,
+    VABufferID *buf_id
+)
+{
+  VADriverContextP ctx;
+  VAStatus vaStatus;
+
+  CHECK_DISPLAY(dpy);
+  ctx = CTX(dpy);
+  if(!ctx->vtable->vaCreateBuffer2)
+     return VA_STATUS_ERROR_UNIMPLEMENTED;
+
+  vaStatus = ctx->vtable->vaCreateBuffer2( ctx, context, type, width, height ,unit_size, pitch, buf_id);
+
+  VA_TRACE_LOG(va_TraceCreateBuffer,
+               dpy, context, type, *pitch, height, NULL, buf_id);
+
+  return vaStatus;
+}
+
 VAStatus vaBufferSetNumElements (
     VADisplay dpy,
     VABufferID buf_id,	/* in */

--- a/va/va.h
+++ b/va/va.h
@@ -2476,6 +2476,28 @@ VAStatus vaCreateBuffer (
 );
 
 /**
+ * Create a buffer for given width & height get unit_size, pitch, buf_id for 2D buffer
+ * for permb qp buffer, it will return unit_size for one MB or LCU and the pitch for alignments
+ * can call vaMapBuffer with this Buffer ID to get virtual address.
+ * e.g. AVC 1080P encode, 1920x1088, the size in MB is 120x68,but inside driver,
+ * maybe it should align with 256, and one byte present one Qp.so, call the function.
+ * then get unit_size = 1, pitch = 256. call vaMapBuffer to get the virtual address (pBuf).
+ * then read write the memory like 2D. the size is 256x68, application can only use 120x68
+ * pBuf + 256 is the start of next line.
+ * different driver implementation maybe return different unit_size and pitch
+ */
+VAStatus vaCreateBuffer2(
+    VADisplay dpy,
+    VAContextID context,
+    VABufferType type,
+    unsigned int width,
+    unsigned int height,
+    unsigned int *unit_size,
+    unsigned int *pitch,
+    VABufferID *buf_id
+);
+
+/**
  * Convey to the server how many valid elements are in the buffer. 
  * e.g. if multiple slice parameters are being held in a single buffer,
  * this will communicate to the server the number of slice parameters

--- a/va/va_backend.h
+++ b/va/va_backend.h
@@ -140,7 +140,7 @@ struct VADriverVTable
 		unsigned int size,		/* in */
 		unsigned int num_elements,	/* in */
 		void *data,			/* in */
-		VABufferID *buf_id		/* out */
+                VABufferID *buf_id
 	);
 
 	VAStatus (*vaBufferSetNumElements) (
@@ -459,8 +459,18 @@ struct VADriverVTable
             VAContextID *contexts,
             int num_contexts
         );
-        /** \brief Reserved bytes for future use, must be zero */
-        unsigned long reserved[60];
+	VAStatus (*vaCreateBuffer2) (
+            VADriverContextP ctx,
+            VAContextID context,                /* in */
+            VABufferType type,                  /* in */
+            unsigned int width,                 /* in */
+            unsigned int height,                /* in */
+            unsigned int *unit_size,            /* out */
+            unsigned int *pitch,                /* out */
+            VABufferID *buf_id                  /* out */
+	);
+
+        unsigned long reserved[59];
 };
 
 struct VADriverContext


### PR DESCRIPTION
standard usage: permb  control buffer, it is always a 2D buffer related with MB Postion

Signed-off-by: Carl.Zhang <carl.zhang@intel.com>