### PR TITLE
va.h: fix comments error for arbitrary number of MBs per slice.

### DIFF
--- a/va/va.h
+++ b/va/va.h
@@ -589,7 +589,7 @@ typedef struct _VAConfigAttrib {
 #define VA_ENC_SLICE_STRUCTURE_ARBITRARY_ROWS           0x00000000
 /** \brief Driver supports a power-of-two number of rows per slice. */
 #define VA_ENC_SLICE_STRUCTURE_POWER_OF_TWO_ROWS        0x00000001
-/** \brief Driver supports an arbitrary number of rows per slice. */
+/** \brief Driver supports an arbitrary number of macroblocks per slice. */
 #define VA_ENC_SLICE_STRUCTURE_ARBITRARY_MACROBLOCKS    0x00000002
 /**@}*/
 


### PR DESCRIPTION
Signed-off-by: Jun Zhao <jun.zhao@intel.com>