### PR TITLE
va: Add the fourcc of I420 format

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -51,28 +51,22 @@ m4_if(libva_pre_version, [0], [], [
 m4_append([libva_version], libva_pre_version, [.pre])
 ])
 
-# libva library version number (generated, do not change)
-# XXX: we want the SONAME to remain at libva.so.1 for VA-API major == 0
+# libva library name (generated, do not change)
 #
-# The library name is generated libva.<x>.<y>.0 where
+# The library name is generated libva-<x>.0.so.0.<y>.0 where
 # <x> = VA-API major version + 1
 # <y> = 100 * VA-API minor version + VA-API micro version
 #
 # For example:
-# VA-API 0.32.0 generates libva.so.1.3200.0
-# VA-API 0.34.1 generates libva.so.1.3401.0
-# VA-API 1.2.13 generates libva.so.2.213.0
-m4_define([libva_interface_bias], [m4_eval(va_api_major_version + 1)])
-m4_define([libva_interface_age],  [0])
-m4_define([libva_binary_age],
-          [m4_eval(100 * va_api_minor_version + va_api_micro_version - libva_interface_age)])
-
+# VA-API 1.0.0 generates libva-2.0.so.0.0.0
+# VA-API 1.0.1 generates libva-2.0.so.0.1.0
+# VA-API 1.1.1 generates libva-2.0.so.0.101.0
 m4_define([libva_lt_current],
-          [m4_eval(100 * va_api_minor_version + va_api_micro_version + libva_interface_bias)])
+          [m4_eval(100 * va_api_minor_version + va_api_micro_version)])
 m4_define([libva_lt_revision],
-          [m4_eval(libva_interface_age)])
+          [0])
 m4_define([libva_lt_age],
-          [m4_eval(libva_binary_age - libva_interface_age)])
+          [m4_eval(100 * va_api_micro_version + va_api_micro_version)])
 
 # libdrm minimun version requirement
 m4_define([libdrm_version], [2.4])
@@ -123,6 +117,13 @@ LIBVA_LT_VERSION="$LIBVA_LT_CURRENT:$LIBVA_LT_REV:$LIBVA_LT_AGE"
 LIBVA_LT_LDFLAGS="-version-info $LIBVA_LT_VERSION"
 AC_SUBST(LIBVA_LT_VERSION)
 AC_SUBST(LIBVA_LT_LDFLAGS)
+
+dnl our libraries and install dirs use LIBVA_LIB_VERSION in the filename
+dnl to allow side-by-side installation of different library versions
+LIBVA_LIB_VERSION=2.0
+AC_SUBST([LIBVA_LIB_VERSION])
+AC_DEFINE_UNQUOTED([LIBVA_LIB_VERSION], ["$LIBVA_LIB_VERSION"],
+  [Libva Library Version])
 
 AC_ARG_ENABLE(docs,
     [AC_HELP_STRING([--enable-docs],

--- a/configure.ac
+++ b/configure.ac
@@ -21,13 +21,13 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 # VA-API version
-# - increment major for any ABI change (which shall not occur!)
+# - increment major for any ABI change
 # - increment minor for any interface change (e.g. new/modified function)
 # - increment micro for any other change (new flag, new codec definition, etc.)
 # - reset micro version to zero when minor version is incremented
 # - reset minor version to zero when major version is incremented
-m4_define([va_api_major_version], [0])
-m4_define([va_api_minor_version], [40])
+m4_define([va_api_major_version], [1])
+m4_define([va_api_minor_version], [0])
 m4_define([va_api_micro_version], [0])
 
 m4_define([va_api_version],
@@ -41,8 +41,8 @@ m4_define([va_api_version],
 # - increment micro for any library release
 # - reset micro version to zero when VA-API major or minor version is changed
 m4_define([libva_major_version], [m4_eval(va_api_major_version + 1)])
-m4_define([libva_minor_version], [m4_eval(va_api_minor_version - 32)])
-m4_define([libva_micro_version], [4])
+m4_define([libva_minor_version], [m4_eval(va_api_minor_version)])
+m4_define([libva_micro_version], [0])
 m4_define([libva_pre_version],   [1])
 
 m4_define([libva_version],

--- a/pkgconfig/Makefile.am
+++ b/pkgconfig/Makefile.am
@@ -20,22 +20,22 @@
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-pcfiles		 = libva.pc
-pcfiles		+= libva-tpi.pc
+pcfiles		 = libva-@LIBVA_LIB_VERSION@.pc
+pcfiles		+= libva-tpi-@LIBVA_LIB_VERSION@.pc
 if USE_DRM
-pcfiles		+= libva-drm.pc
+pcfiles		+= libva-drm-@LIBVA_LIB_VERSION@.pc
 endif
 if USE_X11
-pcfiles		+= libva-x11.pc
+pcfiles		+= libva-x11-@LIBVA_LIB_VERSION@.pc
 endif
 if USE_GLX
-pcfiles		+= libva-glx.pc
+pcfiles		+= libva-glx-@LIBVA_LIB_VERSION@.pc
 endif
 if USE_EGL
-pcfiles		+= libva-egl.pc
+pcfiles		+= libva-egl-@LIBVA_LIB_VERSION@.pc
 endif
 if USE_WAYLAND
-pcfiles		+= libva-wayland.pc
+pcfiles		+= libva-wayland-@LIBVA_LIB_VERSION@.pc
 endif
 
 all_pcfiles_in	 = libva.pc.in
@@ -52,6 +52,10 @@ pkgconfig_DATA = $(pcfiles)
 EXTRA_DIST = $(all_pcfiles_in)
 
 DISTCLEANFILES = $(pcfiles)
+
+### how to generate pc files
+%-@LIBVA_LIB_VERSION@.pc: %.pc
+	@cp $< $@
 
 # Extra clean files so that maintainer-clean removes *everything*
 MAINTAINERCLEANFILES = Makefile.in

--- a/pkgconfig/libva-drm.pc.in
+++ b/pkgconfig/libva-drm.pc.in
@@ -1,12 +1,12 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir=@includedir@
+includedir=@includedir@-@LIBVA_LIB_VERSION@
 display=drm
 
 Name: libva-${display}
 Description: Userspace Video Acceleration (VA) ${display} interface
-Requires: libva
+Requires: libva-@LIBVA_LIB_VERSION@
 Version: @VA_API_VERSION@
-Libs: -L${libdir} -lva-${display}
+Libs: -L${libdir} -lva-${display}-@LIBVA_LIB_VERSION@
 Cflags: -I${includedir}

--- a/pkgconfig/libva-egl.pc.in
+++ b/pkgconfig/libva-egl.pc.in
@@ -1,13 +1,13 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir=@includedir@
+includedir=@includedir@-@LIBVA_LIB_VERSION@
 display=egl
 
 Name: libva-${display}
 Description: Userspace Video Acceleration (VA) ${display} interface
-Requires: libva
+Requires: libva-@LIBVA_LIB_VERSION@
 Version: @VA_API_VERSION@
-Libs: -L${libdir} -lva-${display}
+Libs: -L${libdir} -lva-${display}-@LIBVA_LIB_VERSION@
 Cflags: -I${includedir}
 

--- a/pkgconfig/libva-glx.pc.in
+++ b/pkgconfig/libva-glx.pc.in
@@ -1,12 +1,12 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir=@includedir@
+includedir=@includedir@-@LIBVA_LIB_VERSION@
 display=glx
 
 Name: libva-${display}
 Description: Userspace Video Acceleration (VA) ${display} interface
-Requires: libva
+Requires: libva-@LIBVA_LIB_VERSION@
 Version: @VA_API_VERSION@
-Libs: -L${libdir} -lva-${display}
+Libs: -L${libdir} -lva-${display}-@LIBVA_LIB_VERSION@
 Cflags: -I${includedir}

--- a/pkgconfig/libva-tpi.pc.in
+++ b/pkgconfig/libva-tpi.pc.in
@@ -1,11 +1,11 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir=@includedir@
+includedir=@includedir@-@LIBVA_LIB_VERSION@
 
 Name: libva-tpi
 Description: Userspace Video Acceleration (VA) 3rd party interface
-Requires: libva
+Requires: libva-@LIBVA_LIB_VERSION@
 Version: @VA_API_VERSION@
-Libs: -L${libdir} -lva-tpi
+Libs: -L${libdir} -lva-tpi-@LIBVA_LIB_VERSION@
 Cflags: -I${includedir}

--- a/pkgconfig/libva-wayland.pc.in
+++ b/pkgconfig/libva-wayland.pc.in
@@ -1,12 +1,12 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir=@includedir@
+includedir=@includedir@-@LIBVA_LIB_VERSION@
 display=wayland
 
 Name: libva-${display}
 Description: Userspace Video Acceleration (VA) ${display} interface
-Requires: libva wayland-client
+Requires: libva-@LIBVA_LIB_VERSION@ wayland-client
 Version: @VA_API_VERSION@
-Libs: -L${libdir} -lva-${display}
+Libs: -L${libdir} -lva-${display}-@LIBVA_LIB_VERSION@
 Cflags: -I${includedir}

--- a/pkgconfig/libva-x11.pc.in
+++ b/pkgconfig/libva-x11.pc.in
@@ -1,12 +1,12 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir=@includedir@
+includedir=@includedir@-@LIBVA_LIB_VERSION@
 display=x11
 
 Name: libva-${display}
 Description: Userspace Video Acceleration (VA) ${display} interface
-Requires: libva
+Requires: libva-@LIBVA_LIB_VERSION@
 Version: @VA_API_VERSION@
-Libs: -L${libdir} -lva-${display}
+Libs: -L${libdir} -lva-${display}-@LIBVA_LIB_VERSION@
 Cflags: -I${includedir}

--- a/pkgconfig/libva.pc.in
+++ b/pkgconfig/libva.pc.in
@@ -1,11 +1,11 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir=@includedir@
+includedir=@includedir@/va-@LIBVA_LIB_VERSION@
 driverdir=@LIBVA_DRIVERS_PATH@
 
 Name: libva
 Description: Userspace Video Acceleration (VA) core interface
 Version: @VA_API_VERSION@
-Libs: -L${libdir} -lva
+Libs: -L${libdir} -lva-@LIBVA_LIB_VERSION@
 Cflags: -I${includedir}

--- a/va/Makefile.am
+++ b/va/Makefile.am
@@ -69,69 +69,69 @@ libva_ldflags = \
 	-Wl,-version-script,${srcdir}/libva.syms \
 	$(NULL)
 
-lib_LTLIBRARIES			= libva.la
-libvaincludedir			= ${includedir}/va
-libvainclude_HEADERS		= $(libva_source_h)
-noinst_HEADERS			= $(libva_source_h_priv)
-libva_la_SOURCES		= $(libva_source_c)
-libva_la_LDFLAGS		= $(libva_ldflags)
-libva_la_DEPENDENCIES		= libva.syms
-libva_la_LIBADD			= $(LIBVA_LIBS) -ldl
+lib_LTLIBRARIES				= libva-@LIBVA_LIB_VERSION@.la
+libva_@LIBVA_LIB_VERSION@_includedir		= ${includedir}/va-@LIBVA_LIB_VERSION@/va
+libva_@LIBVA_LIB_VERSION@_include_HEADERS	= $(libva_source_h)
+noinst_HEADERS					= $(libva_source_h_priv)
+libva_@LIBVA_LIB_VERSION@_la_SOURCES		= $(libva_source_c)
+libva_@LIBVA_LIB_VERSION@_la_LDFLAGS		= $(libva_ldflags)
+libva_@LIBVA_LIB_VERSION@_la_DEPENDENCIES	= libva.syms
+libva_@LIBVA_LIB_VERSION@_la_LIBADD		= $(LIBVA_LIBS) -ldl
 
-lib_LTLIBRARIES			+= libva-tpi.la
-libva_tpi_la_SOURCES		= va_tpi.c
-libva_tpi_la_LDFLAGS		= $(LDADD) -no-undefined
-libva_tpi_la_DEPENDENCIES	= libva.la 
-libva_tpi_la_LIBADD		= libva.la -ldl
+lib_LTLIBRARIES				+= libva-tpi-@LIBVA_LIB_VERSION@.la
+libva_tpi_@LIBVA_LIB_VERSION@_la_SOURCES	= va_tpi.c
+libva_tpi_@LIBVA_LIB_VERSION@_la_LDFLAGS	= $(LDADD) -no-undefined
+libva_tpi_@LIBVA_LIB_VERSION@_la_DEPENDENCIES	= libva-@LIBVA_LIB_VERSION@.la
+libva_tpi_@LIBVA_LIB_VERSION@_la_LIBADD		= libva-@LIBVA_LIB_VERSION@.la -ldl
 
 if USE_DRM
 SUBDIRS				+= drm
-lib_LTLIBRARIES			+= libva-drm.la
-libva_drm_la_SOURCES		=
-libva_drm_la_LDFLAGS		= $(LDADD)
-libva_drm_la_DEPENDENCIES	= libva.la drm/libva_drm.la
-libva_drm_la_LIBADD		= libva.la drm/libva_drm.la \
+lib_LTLIBRARIES			+= libva-drm-@LIBVA_LIB_VERSION@.la
+libva_drm_@LIBVA_LIB_VERSION@_la_SOURCES	=
+libva_drm_@LIBVA_LIB_VERSION@_la_LDFLAGS	= $(LDADD)
+libva_drm_@LIBVA_LIB_VERSION@_la_DEPENDENCIES	= libva-@LIBVA_LIB_VERSION@.la drm/libva_drm.la
+libva_drm_@LIBVA_LIB_VERSION@_la_LIBADD		= libva-@LIBVA_LIB_VERSION@.la drm/libva_drm.la \
 	$(LIBVA_LIBS) $(DRM_LIBS) -ldl
 endif
 
 if USE_X11
 SUBDIRS				+= x11
-lib_LTLIBRARIES			+= libva-x11.la
-libva_source_h			+= va_x11.h
-libva_x11_la_SOURCES		= 
-libva_x11_la_LDFLAGS		= $(LDADD)
-libva_x11_la_DEPENDENCIES	= libva.la x11/libva_x11.la
-libva_x11_la_LIBADD		= libva.la x11/libva_x11.la \
+lib_LTLIBRARIES			+= libva-x11-@LIBVA_LIB_VERSION@.la
+libva_source_h					+= va_x11.h
+libva_x11_@LIBVA_LIB_VERSION@_la_SOURCES	=
+libva_x11_@LIBVA_LIB_VERSION@_la_LDFLAGS	= $(LDADD)
+libva_x11_@LIBVA_LIB_VERSION@_la_DEPENDENCIES	= libva-@LIBVA_LIB_VERSION@.la x11/libva_x11.la
+libva_x11_@LIBVA_LIB_VERSION@_la_LIBADD		= libva-@LIBVA_LIB_VERSION@.la x11/libva_x11.la \
 	$(LIBVA_LIBS) $(X11_LIBS) $(XEXT_LIBS) $(XFIXES_LIBS) $(DRM_LIBS) -ldl
 endif
 
 if USE_GLX
 SUBDIRS				+= glx
-lib_LTLIBRARIES			+= libva-glx.la
-libva_glx_la_SOURCES		=
-libva_glx_la_LDFLAGS		= $(LDADD)
-libva_glx_la_DEPENDENCIES	= libva.la glx/libva_glx.la libva-x11.la
-libva_glx_la_LIBADD		= libva.la glx/libva_glx.la libva-x11.la \
+lib_LTLIBRARIES			+= libva-glx-@LIBVA_LIB_VERSION@.la
+libva_glx_@LIBVA_LIB_VERSION@_la_SOURCES	=
+libva_glx_@LIBVA_LIB_VERSION@_la_LDFLAGS	= $(LDADD)
+libva_glx_@LIBVA_LIB_VERSION@_la_DEPENDENCIES	= libva-@LIBVA_LIB_VERSION@.la glx/libva_glx.la libva-x11-@LIBVA_LIB_VERSION@.la
+libva_glx_@LIBVA_LIB_VERSION@_la_LIBADD		= libva-@LIBVA_LIB_VERSION@.la glx/libva_glx.la libva-x11-@LIBVA_LIB_VERSION@.la \
 	$(GLX_LIBS) -ldl
 endif
 
 if USE_EGL
 SUBDIRS				+= egl
-lib_LTLIBRARIES			+= libva-egl.la
-libva_egl_la_SOURCES		=
-libva_egl_la_LDFLAGS		= $(LDADD)
-libva_egl_la_DEPENDENCIES	= libva.la egl/libva_egl.la 
-libva_egl_la_LIBADD		= libva.la egl/libva_egl.la \
+lib_LTLIBRARIES			+= libva-egl-@LIBVA_LIB_VERSION@.la
+libva_egl_@LIBVA_LIB_VERSION@_la_SOURCES	=
+libva_egl_@LIBVA_LIB_VERSION@_la_LDFLAGS	= $(LDADD)
+libva_egl_@LIBVA_LIB_VERSION@_la_DEPENDENCIES	= libva-@LIBVA_LIB_VERSION@.la egl/libva_egl.la
+libva_egl_@LIBVA_LIB_VERSION@_la_LIBADD		= libva-@LIBVA_LIB_VERSION@.la egl/libva_egl.la \
 	$(EGL_LIBS) -ldl
 endif
 
 if USE_WAYLAND
 SUBDIRS				+= wayland
-lib_LTLIBRARIES			+= libva-wayland.la
-libva_wayland_la_SOURCES	=
-libva_wayland_la_LDFLAGS	= $(LDADD)
-libva_wayland_la_DEPENDENCIES	= libva.la wayland/libva_wayland.la
-libva_wayland_la_LIBADD		= libva.la wayland/libva_wayland.la \
+lib_LTLIBRARIES			+= libva-wayland-@LIBVA_LIB_VERSION@.la
+libva_wayland_@LIBVA_LIB_VERSION@_la_SOURCES		=
+libva_wayland_@LIBVA_LIB_VERSION@_la_LDFLAGS		= $(LDADD)
+libva_wayland_@LIBVA_LIB_VERSION@_la_DEPENDENCIES	= libva-@LIBVA_LIB_VERSION@.la wayland/libva_wayland.la
+libva_wayland_@LIBVA_LIB_VERSION@_la_LIBADD		= libva-@LIBVA_LIB_VERSION@.la wayland/libva_wayland.la \
 	$(WAYLAND_LIBS) $(DRM_LIBS) -ldl
 endif
 

--- a/va/android/va_android.cpp
+++ b/va/android/va_android.cpp
@@ -26,6 +26,7 @@
 #include "sysdeps.h"
 #include "va.h"
 #include "va_backend.h"
+#include "va_internal.h"
 #include "va_trace.h"
 #include "va_fool.h"
 #include "va_android.h"
@@ -135,13 +136,11 @@ VADisplay vaGetDisplay (
         /* create new entry */
         VADriverContextP pDriverContext = 0;
         struct drm_state *drm_state = 0;
-        pDisplayContext = (VADisplayContextP)calloc(1, sizeof(*pDisplayContext));
+        pDisplayContext = va_newDisplayContext();
         pDriverContext  = (VADriverContextP)calloc(1, sizeof(*pDriverContext));
         drm_state       = (struct drm_state*)calloc(1, sizeof(*drm_state));
         if (pDisplayContext && pDriverContext && drm_state)
         {
-            pDisplayContext->vadpy_magic = VA_DISPLAY_MAGIC;          
-
             pDriverContext->native_dpy       = (void *)native_dpy;
             pDriverContext->display_type     = VA_DISPLAY_ANDROID;
             pDisplayContext->pDriverContext  = pDriverContext;

--- a/va/android/va_android.cpp
+++ b/va/android/va_android.cpp
@@ -165,9 +165,6 @@ VADisplay vaGetDisplay (
     return dpy;
 }
 
-#define CTX(dpy) (((VADisplayContextP)dpy)->pDriverContext)
-#define CHECK_DISPLAY(dpy) if( !vaDisplayIsValid(dpy) ) { return VA_STATUS_ERROR_INVALID_DISPLAY; }
-
 
 extern "C"  {
     extern int fool_postp; /* do nothing for vaPutSurface if set */

--- a/va/android/va_android.cpp
+++ b/va/android/va_android.cpp
@@ -166,8 +166,8 @@ VADisplay vaGetDisplay (
 
 
 extern "C"  {
-    extern int fool_postp; /* do nothing for vaPutSurface if set */
-    extern int trace_flag; /* trace vaPutSurface parameters */
+    extern int va_fool_postp; /* do nothing for vaPutSurface if set */
+    extern int va_trace_flag; /* trace vaPutSurface parameters */
 
     void va_TracePutSurface (
         VADisplay dpy,

--- a/va/drm/Makefile.am
+++ b/va/drm/Makefile.am
@@ -49,7 +49,7 @@ AM_CPPFLAGS			+= $(X11_CFLAGS)
 endif
 
 noinst_LTLIBRARIES		= libva_drm.la
-libva_drmincludedir		= ${includedir}/va
+libva_drmincludedir		= ${includedir}/va-@LIBVA_LIB_VERSION@/va
 libva_drminclude_HEADERS	= $(source_h)
 libva_drm_la_SOURCES		= $(source_c)
 noinst_HEADERS			= $(source_h_priv)

--- a/va/drm/va_drm.c
+++ b/va/drm/va_drm.c
@@ -26,6 +26,7 @@
 #include <xf86drm.h>
 #include "va_drm.h"
 #include "va_backend.h"
+#include "va_internal.h"
 #include "va_drmcommon.h"
 #include "va_drm_auth.h"
 #include "va_drm_utils.h"
@@ -109,11 +110,10 @@ vaGetDisplayDRM(int fd)
         VA_DISPLAY_DRM_RENDERNODES : VA_DISPLAY_DRM;
     pDriverContext->drm_state    = drm_state;
 
-    pDisplayContext = calloc(1, sizeof(*pDisplayContext));
+    pDisplayContext = va_newDisplayContext();
     if (!pDisplayContext)
         goto error;
 
-    pDisplayContext->vadpy_magic     = VA_DISPLAY_MAGIC;
     pDisplayContext->pDriverContext  = pDriverContext;
     pDisplayContext->vaIsValid       = va_DisplayContextIsValid;
     pDisplayContext->vaDestroy       = va_DisplayContextDestroy;

--- a/va/egl/Makefile.am
+++ b/va/egl/Makefile.am
@@ -37,7 +37,7 @@ source_h = \
 source_h_priv = 
 
 noinst_LTLIBRARIES	 = libva_egl.la
-libva_eglincludedir	 = ${includedir}/va
+libva_eglincludedir	 = ${includedir}/va-@LIBVA_LIB_VERSION@/va
 libva_eglinclude_HEADERS = $(source_h)
 libva_egl_la_SOURCES	 = $(source_c)
 noinst_HEADERS		 = $(source_h_priv)

--- a/va/egl/va_egl.c
+++ b/va/egl/va_egl.c
@@ -57,9 +57,8 @@
 #include "va.h"
 #include "va_backend_egl.h"
 #include "va_egl.h"
+#include "va_internal.h"
 
-#define CTX(dpy) (((VADisplayContextP)dpy)->pDriverContext)
-#define CHECK_DISPLAY(dpy) if( !vaDisplayIsValid(dpy) ) { return VA_STATUS_ERROR_INVALID_DISPLAY; }
 
 VAStatus vaGetEGLClientBufferFromSurface (
     VADisplay dpy,

--- a/va/egl/va_egl.h
+++ b/va/egl/va_egl.h
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2007 Intel Corporation. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sub license, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the
+ * next paragraph) shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
+ * IN NO EVENT SHALL PRECISION INSIGHT AND/OR ITS SUPPLIERS BE LIABLE FOR
+ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 #ifndef _VA_EGL_H_
 #define _VA_EGL_H_
 

--- a/va/glx/Makefile.am
+++ b/va/glx/Makefile.am
@@ -45,7 +45,7 @@ source_h_priv = \
 	$(NULL)
 
 noinst_LTLIBRARIES		 = libva_glx.la
-libva_glxincludedir		 = ${includedir}/va
+libva_glxincludedir		 = ${includedir}/va-@LIBVA_LIB_VERSION@/va
 libva_glxinclude_HEADERS	 = $(source_h)
 libva_glx_la_SOURCES		 = $(source_c)
 noinst_HEADERS			 = $(source_h_priv)

--- a/va/va.c
+++ b/va/va.c
@@ -50,9 +50,6 @@
 
 #define DRIVER_EXTENSION	"_drv_video.so"
 
-#define CTX(dpy) (((VADisplayContextP)dpy)->pDriverContext)
-#define CHECK_DISPLAY(dpy) if( !vaDisplayIsValid(dpy) ) { return VA_STATUS_ERROR_INVALID_DISPLAY; }
-
 #define ASSERT		assert
 #define CHECK_VTABLE(s, ctx, func) if (!va_checkVtable(ctx->vtable->va##func, #func)) s = VA_STATUS_ERROR_UNKNOWN;
 #define CHECK_MAXIMUM(s, ctx, var) if (!va_checkMaximum(ctx->max_##var, #var)) s = VA_STATUS_ERROR_UNKNOWN;

--- a/va/va.c
+++ b/va/va.c
@@ -331,14 +331,6 @@ static VAStatus va_openDriver(VADisplay dpy, char *driver_name)
                 int minor;
             } compatible_versions[] = {
                 { VA_MAJOR_VERSION, VA_MINOR_VERSION },
-                { 0, 39 },
-                { 0, 38 },
-                { 0, 37 },
-                { 0, 36 },
-                { 0, 35 },
-                { 0, 34 },
-                { 0, 33 },
-                { 0, 32 },
                 { -1, }
             };
 

--- a/va/va.c
+++ b/va/va.c
@@ -27,6 +27,7 @@
 #include "va.h"
 #include "va_backend.h"
 #include "va_backend_vpp.h"
+#include "va_internal.h"
 #include "va_trace.h"
 #include "va_fool.h"
 
@@ -232,6 +233,17 @@ void va_infoMessage(const char *msg, ...)
     else if (len > 0)
         va_log_info(buf);
 #endif
+}
+
+VADisplayContextP va_newDisplayContext(void)
+{
+    VADisplayContextP dctx = calloc(1, sizeof(*dctx));
+    if (!dctx)
+        return NULL;
+
+    dctx->vadpy_magic = VA_DISPLAY_MAGIC;
+
+    return dctx;
 }
 
 static bool va_checkVtable(void *ptr, char *function)

--- a/va/va.c
+++ b/va/va.c
@@ -49,7 +49,7 @@
 #endif
 #endif
 
-#define DRIVER_EXTENSION	"_drv_video.so"
+#define DRIVER_EXTENSION	"_drv_video-2.0.so"
 
 #define ASSERT		assert
 #define CHECK_VTABLE(s, ctx, func) if (!va_checkVtable(dpy, ctx->vtable->va##func, #func)) s = VA_STATUS_ERROR_UNKNOWN;

--- a/va/va.h
+++ b/va/va.h
@@ -231,19 +231,19 @@ typedef struct _VARectangle
 } VARectangle;
 
 /** Type of a message callback, used for both error and info log. */
-typedef void (*vaMessageCallback)(const char *message);
+typedef void (*VAMessageCallback)(void *user_context, const char *message);
 
 /**
  * Set the callback for error messages, or NULL for no logging.
  * Returns the previous one, or NULL if it was disabled.
  */
-vaMessageCallback vaSetErrorCallback(vaMessageCallback);
+VAMessageCallback vaSetErrorCallback(VADisplay dpy, VAMessageCallback callback, void *user_context);
 
 /**
  * Set the callback for info messages, or NULL for no logging.
  * Returns the previous one, or NULL if it was disabled.
  */
-vaMessageCallback vaSetInfoCallback(vaMessageCallback);
+VAMessageCallback vaSetInfoCallback(VADisplay dpy, VAMessageCallback callback, void *user_context);
 
 /**
  * Initialization:

--- a/va/va.h
+++ b/va/va.h
@@ -86,6 +86,18 @@
 extern "C" {
 #endif
 
+#ifdef __GNUC__
+#define va_deprecated __attribute__((deprecated))
+#if __GNUC__ >= 6
+#define va_deprecated_enum va_deprecated
+#else
+#define va_deprecated_enum
+#endif
+#else
+#define va_deprecated
+#define va_deprecated_enum
+#endif
+
 /**
  * \mainpage Video Acceleration (VA) API
  *

--- a/va/va.h
+++ b/va/va.h
@@ -1979,7 +1979,7 @@ typedef struct _VAPictureParameterBufferH264
     union {
         struct {
             unsigned int chroma_format_idc			: 2; 
-            unsigned int residual_colour_transform_flag		: 1; 
+            unsigned int residual_colour_transform_flag		: 1; /* Renamed to separate_colour_plane_flag in newer standard versions. */
             unsigned int gaps_in_frame_num_value_allowed_flag	: 1; 
             unsigned int frame_mbs_only_flag			: 1; 
             unsigned int mb_adaptive_frame_field_flag		: 1; 
@@ -2008,7 +2008,7 @@ typedef struct _VAPictureParameterBufferH264
             unsigned int transform_8x8_mode_flag	: 1;
             unsigned int field_pic_flag			: 1;
             unsigned int constrained_intra_pred_flag	: 1;
-            unsigned int pic_order_present_flag			: 1;
+            unsigned int pic_order_present_flag			: 1; /* Renamed to bottom_field_pic_order_in_frame_present_flag in newer standard versions. */
             unsigned int deblocking_filter_control_present_flag : 1;
             unsigned int redundant_pic_cnt_present_flag		: 1;
             unsigned int reference_pic_flag			: 1; /* nal_ref_idc != 0 */

--- a/va/va.h
+++ b/va/va.h
@@ -2540,7 +2540,9 @@ VAStatus vaQuerySurfaceError(
 #define VA_FOURCC_NV11          0x3131564e
 #define VA_FOURCC_YV12          0x32315659
 #define VA_FOURCC_P208          0x38303250
+/* IYUV same as I420, but most user perfer I420, will deprecate it */
 #define VA_FOURCC_IYUV          0x56555949
+#define VA_FOURCC_I420          0x30323449
 #define VA_FOURCC_YV24          0x34325659
 #define VA_FOURCC_YV32          0x32335659
 #define VA_FOURCC_Y800          0x30303859

--- a/va/va.h
+++ b/va/va.h
@@ -324,7 +324,7 @@ typedef enum
     VAProfileMPEG4Simple		= 2,
     VAProfileMPEG4AdvancedSimple	= 3,
     VAProfileMPEG4Main			= 4,
-    VAProfileH264Baseline		= 5,
+    VAProfileH264Baseline va_deprecated_enum = 5,
     VAProfileH264Main			= 6,
     VAProfileH264High			= 7,
     VAProfileVC1Simple			= 8,
@@ -1992,9 +1992,10 @@ typedef struct _VAPictureParameterBufferH264
         } bits;
         unsigned int value;
     } seq_fields;
-    unsigned char num_slice_groups_minus1;
-    unsigned char slice_group_map_type;
-    unsigned short slice_group_change_rate_minus1;
+    // FMO is not supported.
+    va_deprecated unsigned char num_slice_groups_minus1;
+    va_deprecated unsigned char slice_group_map_type;
+    va_deprecated unsigned short slice_group_change_rate_minus1;
     signed char pic_init_qp_minus26;
     signed char pic_init_qs_minus26;
     signed char chroma_qp_index_offset;
@@ -2025,16 +2026,6 @@ typedef struct _VAIQMatrixBufferH264
     /** \brief 8x8 scaling list, in raster scan order. */
     unsigned char ScalingList8x8[2][64];
 } VAIQMatrixBufferH264;
-
-/**
- * H.264 Slice Group Map Buffer 
- * When VAPictureParameterBufferH264::num_slice_group_minus1 is not equal to 0,
- * A slice group map buffer should be sent for each picture if required. The buffer
- * is sent only when there is a change in the mapping values.
- * The slice group map buffer map "map units" to slice groups as specified in 
- * section 8.2.2 of the H.264 spec. The buffer will contain one byte for each macroblock 
- * in raster scan order
- */ 
 
 /** H.264 Slice Parameter Buffer */
 typedef struct _VASliceParameterBufferH264

--- a/va/va_backend.h
+++ b/va/va_backend.h
@@ -553,6 +553,11 @@ struct VADisplayContext
     void *opaque; /* opaque for display extensions (e.g. GLX) */
     void *vatrace; /* opaque for VA trace context */
     void *vafool; /* opaque for VA fool context */
+
+    VAMessageCallback error_callback;
+    void *error_callback_user_context;
+    VAMessageCallback info_callback;
+    void *info_callback_user_context;
 };
 
 typedef VAStatus (*VADriverInit) (

--- a/va/va_dec_hevc.h
+++ b/va/va_dec_hevc.h
@@ -254,7 +254,7 @@ typedef struct  _VASliceParameterBufferHEVC
     /** \brief The offset to the NAL unit header for this slice */
     uint32_t                slice_data_offset;
     /** \brief Slice data buffer flags. See \c VA_SLICE_DATA_FLAG_XXX. */
-    uint16_t                slice_data_flag;
+    uint32_t                slice_data_flag;
     /**
      * \brief Byte offset from NAL unit header to the begining of slice_data().
      *

--- a/va/va_fool.c
+++ b/va/va_fool.c
@@ -26,6 +26,7 @@
 #include "sysdeps.h"
 #include "va.h"
 #include "va_backend.h"
+#include "va_internal.h"
 #include "va_trace.h"
 #include "va_fool.h"
 
@@ -102,12 +103,6 @@ struct fool_context {
     if ((fool_ctx == NULL) || (fool_ctx->enabled == 0))  \
         return 0; /* no fool for the context */          \
 
-/* Prototype declarations (functions defined in va.c) */
-
-void va_errorMessage(const char *msg, ...);
-void va_infoMessage(const char *msg, ...);
-
-int  va_parseConfig(char *env, char *env_value);
 
 void va_FoolInit(VADisplay dpy)
 {

--- a/va/va_fool.c
+++ b/va/va_fool.c
@@ -62,14 +62,14 @@
 
 
 /* global settings */
-int fool_codec = 0;
-int fool_postp  = 0;
+int va_fool_codec = 0;
+int va_fool_postp  = 0;
 
 #define FOOL_BUFID_MAGIC   0x12345600
 #define FOOL_BUFID_MASK    0xffffff00
 
 struct fool_context {
-    int enabled; /* fool_codec is global, and it is for concurent encode/decode */
+    int enabled; /* va_fool_codec is global, and it is for concurent encode/decode */
     char *fn_enc;/* file pattern with codedbuf content for encode */
     char *segbuf_enc; /* the segment buffer of coded buffer, load frome fn_enc */
     int file_count;
@@ -114,22 +114,22 @@ void va_FoolInit(VADisplay dpy)
         return;
     
     if (va_parseConfig("LIBVA_FOOL_POSTP", NULL) == 0) {
-        fool_postp = 1;
+        va_fool_postp = 1;
         va_infoMessage(dpy, "LIBVA_FOOL_POSTP is on, dummy vaPutSurface\n");
     }
     
     if (va_parseConfig("LIBVA_FOOL_DECODE", NULL) == 0) {
-        fool_codec  |= VA_FOOL_FLAG_DECODE;
+        va_fool_codec  |= VA_FOOL_FLAG_DECODE;
         va_infoMessage(dpy, "LIBVA_FOOL_DECODE is on, dummy decode\n");
     }
     if (va_parseConfig("LIBVA_FOOL_ENCODE", &env_value[0]) == 0) {
-        fool_codec  |= VA_FOOL_FLAG_ENCODE;
+        va_fool_codec  |= VA_FOOL_FLAG_ENCODE;
         fool_ctx->fn_enc = strdup(env_value);
         va_infoMessage(dpy, "LIBVA_FOOL_ENCODE is on, load encode data from file with patten %s\n",
                        fool_ctx->fn_enc);
     }
     if (va_parseConfig("LIBVA_FOOL_JPEG", &env_value[0]) == 0) {
-        fool_codec  |= VA_FOOL_FLAG_JPEG;
+        va_fool_codec  |= VA_FOOL_FLAG_JPEG;
         fool_ctx->fn_jpg = strdup(env_value);
         va_infoMessage(dpy, "LIBVA_FOOL_JPEG is on, load encode data from file with patten %s\n",
                        fool_ctx->fn_jpg);
@@ -177,15 +177,15 @@ int va_FoolCreateConfig(
     fool_ctx->entrypoint = entrypoint;
     
     /*
-     * check fool_codec to align with current context
-     * e.g. fool_codec = decode then for encode, the
+     * check va_fool_codec to align with current context
+     * e.g. va_fool_codec = decode then for encode, the
      * vaBegin/vaRender/vaEnd also run into fool path
      * which is not desired
      */
-    if (((fool_codec & VA_FOOL_FLAG_DECODE) && (entrypoint == VAEntrypointVLD)) ||
-        ((fool_codec & VA_FOOL_FLAG_JPEG) && (entrypoint == VAEntrypointEncPicture)))
+    if (((va_fool_codec & VA_FOOL_FLAG_DECODE) && (entrypoint == VAEntrypointVLD)) ||
+        ((va_fool_codec & VA_FOOL_FLAG_JPEG) && (entrypoint == VAEntrypointEncPicture)))
         fool_ctx->enabled = 1;
-    else if ((fool_codec & VA_FOOL_FLAG_ENCODE) && (entrypoint == VAEntrypointEncSlice)) {
+    else if ((va_fool_codec & VA_FOOL_FLAG_ENCODE) && (entrypoint == VAEntrypointEncSlice)) {
         /* H264 is desired */
         if (((profile == VAProfileH264Baseline ||
               profile == VAProfileH264Main ||

--- a/va/va_fool.c
+++ b/va/va_fool.c
@@ -115,23 +115,23 @@ void va_FoolInit(VADisplay dpy)
     
     if (va_parseConfig("LIBVA_FOOL_POSTP", NULL) == 0) {
         fool_postp = 1;
-        va_infoMessage("LIBVA_FOOL_POSTP is on, dummy vaPutSurface\n");
+        va_infoMessage(dpy, "LIBVA_FOOL_POSTP is on, dummy vaPutSurface\n");
     }
     
     if (va_parseConfig("LIBVA_FOOL_DECODE", NULL) == 0) {
         fool_codec  |= VA_FOOL_FLAG_DECODE;
-        va_infoMessage("LIBVA_FOOL_DECODE is on, dummy decode\n");
+        va_infoMessage(dpy, "LIBVA_FOOL_DECODE is on, dummy decode\n");
     }
     if (va_parseConfig("LIBVA_FOOL_ENCODE", &env_value[0]) == 0) {
         fool_codec  |= VA_FOOL_FLAG_ENCODE;
         fool_ctx->fn_enc = strdup(env_value);
-        va_infoMessage("LIBVA_FOOL_ENCODE is on, load encode data from file with patten %s\n",
+        va_infoMessage(dpy, "LIBVA_FOOL_ENCODE is on, load encode data from file with patten %s\n",
                        fool_ctx->fn_enc);
     }
     if (va_parseConfig("LIBVA_FOOL_JPEG", &env_value[0]) == 0) {
         fool_codec  |= VA_FOOL_FLAG_JPEG;
         fool_ctx->fn_jpg = strdup(env_value);
-        va_infoMessage("LIBVA_FOOL_JPEG is on, load encode data from file with patten %s\n",
+        va_infoMessage(dpy, "LIBVA_FOOL_JPEG is on, load encode data from file with patten %s\n",
                        fool_ctx->fn_jpg);
     }
     
@@ -200,9 +200,9 @@ int va_FoolCreateConfig(
             fool_ctx->enabled = 1;
     }
     if (fool_ctx->enabled)
-        va_infoMessage("FOOL is enabled for this context\n");
+        va_infoMessage(dpy, "FOOL is enabled for this context\n");
     else
-        va_infoMessage("FOOL is not enabled for this context\n");
+        va_infoMessage(dpy, "FOOL is not enabled for this context\n");
 
     
     return 0; /* continue */

--- a/va/va_fool.c
+++ b/va/va_fool.c
@@ -269,6 +269,7 @@ static int va_FoolFillCodedBufEnc(struct fool_context *fool_ctx)
     struct stat file_stat = {0};
     VACodedBufferSegment *codedbuf;
     int i, fd = -1;
+    ssize_t ret;
 
     /* try file_name.file_count, if fail, try file_name.file_count-- */
     for (i=0; i<=1; i++) {
@@ -285,7 +286,9 @@ static int va_FoolFillCodedBufEnc(struct fool_context *fool_ctx)
     }
     if (fd != -1) {
         fool_ctx->segbuf_enc = realloc(fool_ctx->segbuf_enc, file_stat.st_size);
-        read(fd, fool_ctx->segbuf_enc, file_stat.st_size);
+        ret = read(fd, fool_ctx->segbuf_enc, file_stat.st_size);
+        if (ret < file_stat.st_size)
+            va_errorMessage("Reading file %s failed.\n", file_name);
         close(fd);
     } else
         va_errorMessage("Open file %s failed:%s\n", file_name, strerror(errno));
@@ -306,11 +309,14 @@ static int va_FoolFillCodedBufJPG(struct fool_context *fool_ctx)
     struct stat file_stat = {0};
     VACodedBufferSegment *codedbuf;
     int fd = -1;
+    ssize_t ret;
 
     if ((fd = open(fool_ctx->fn_jpg, O_RDONLY)) != -1) {
         fstat(fd, &file_stat);
         fool_ctx->segbuf_jpg = realloc(fool_ctx->segbuf_jpg, file_stat.st_size);
-        read(fd, fool_ctx->segbuf_jpg, file_stat.st_size);
+        ret = read(fd, fool_ctx->segbuf_jpg, file_stat.st_size);
+        if (ret < file_stat.st_size)
+            va_errorMessage("Reading file %s failed.\n", fool_ctx->fn_jpg);
         close(fd);
     } else
         va_errorMessage("Open file %s failed:%s\n", fool_ctx->fn_jpg, strerror(errno));

--- a/va/va_fool.h
+++ b/va/va_fool.h
@@ -32,15 +32,15 @@
 extern "C" {
 #endif
 
-extern int fool_codec;
-extern int fool_postp;
+extern int va_fool_codec;
+extern int va_fool_postp;
 
 #define VA_FOOL_FLAG_DECODE  0x1
 #define VA_FOOL_FLAG_ENCODE  0x2
 #define VA_FOOL_FLAG_JPEG    0x4
 
 #define VA_FOOL_FUNC(fool_func,...)            \
-    if (fool_codec) {                          \
+    if (va_fool_codec) {                       \
         if (fool_func(__VA_ARGS__))            \
             return VA_STATUS_SUCCESS;          \
     }

--- a/va/va_internal.h
+++ b/va/va_internal.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017 Intel Corporation. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sub license, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the
+ * next paragraph) shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
+ * IN NO EVENT SHALL PRECISION INSIGHT AND/OR ITS SUPPLIERS BE LIABLE FOR
+ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef VA_INTERNAL_H
+#define VA_INTERNAL_H
+
+void va_errorMessage(const char *msg, ...);
+void va_infoMessage(const char *msg, ...);
+
+int  va_parseConfig(char *env, char *env_value);
+
+#endif /* VA_INTERNAL_H */

--- a/va/va_internal.h
+++ b/va/va_internal.h
@@ -25,6 +25,9 @@
 #ifndef VA_INTERNAL_H
 #define VA_INTERNAL_H
 
+#define CTX(dpy) (((VADisplayContextP)dpy)->pDriverContext)
+#define CHECK_DISPLAY(dpy) if( !vaDisplayIsValid(dpy) ) { return VA_STATUS_ERROR_INVALID_DISPLAY; }
+
 void va_errorMessage(const char *msg, ...);
 void va_infoMessage(const char *msg, ...);
 

--- a/va/va_internal.h
+++ b/va/va_internal.h
@@ -28,8 +28,8 @@
 #define CTX(dpy) (((VADisplayContextP)dpy)->pDriverContext)
 #define CHECK_DISPLAY(dpy) if( !vaDisplayIsValid(dpy) ) { return VA_STATUS_ERROR_INVALID_DISPLAY; }
 
-void va_errorMessage(const char *msg, ...);
-void va_infoMessage(const char *msg, ...);
+void va_errorMessage(VADisplay dpy, const char *msg, ...);
+void va_infoMessage(VADisplay dpy, const char *msg, ...);
 
 int  va_parseConfig(char *env, char *env_value);
 

--- a/va/va_internal.h
+++ b/va/va_internal.h
@@ -33,4 +33,6 @@ void va_infoMessage(const char *msg, ...);
 
 int  va_parseConfig(char *env, char *env_value);
 
+VADisplayContextP va_newDisplayContext(void);
+
 #endif /* VA_INTERNAL_H */

--- a/va/va_tpi.c
+++ b/va/va_tpi.c
@@ -27,6 +27,7 @@
 #include "va.h"
 #include "va_backend.h"
 #include "va_backend_tpi.h"
+#include "va_internal.h"
 
 #include <assert.h>
 #include <stdarg.h>
@@ -35,9 +36,6 @@
 #include <string.h>
 #include <dlfcn.h>
 #include <unistd.h>
-
-#define CTX(dpy) (((VADisplayContextP)dpy)->pDriverContext)
-#define CHECK_DISPLAY(dpy) if( !vaDisplayIsValid(dpy) ) { return VA_STATUS_ERROR_INVALID_DISPLAY; }
 
 
 /*

--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -2670,9 +2670,6 @@ static void va_TraceVAPictureParameterBufferH264(
     va_TraceMsg(trace_ctx, "\tmb_adaptive_frame_field_flag = %d\n", p->seq_fields.bits.mb_adaptive_frame_field_flag);
     va_TraceMsg(trace_ctx, "\tdirect_8x8_inference_flag = %d\n", p->seq_fields.bits.direct_8x8_inference_flag);
     va_TraceMsg(trace_ctx, "\tMinLumaBiPredSize8x8 = %d\n", p->seq_fields.bits.MinLumaBiPredSize8x8);
-    va_TraceMsg(trace_ctx, "\tnum_slice_groups_minus1 = %d\n", p->num_slice_groups_minus1);
-    va_TraceMsg(trace_ctx, "\tslice_group_map_type = %d\n", p->slice_group_map_type);
-    va_TraceMsg(trace_ctx, "\tslice_group_change_rate_minus1 = %d\n", p->slice_group_change_rate_minus1);
     va_TraceMsg(trace_ctx, "\tpic_init_qp_minus26 = %d\n", p->pic_init_qp_minus26);
     va_TraceMsg(trace_ctx, "\tpic_init_qs_minus26 = %d\n", p->pic_init_qs_minus26);
     va_TraceMsg(trace_ctx, "\tchroma_qp_index_offset = %d\n", p->chroma_qp_index_offset);

--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -28,6 +28,7 @@
 #include "va.h"
 #include "va_enc_h264.h"
 #include "va_backend.h"
+#include "va_internal.h"
 #include "va_trace.h"
 #include "va_enc_h264.h"
 #include "va_enc_jpeg.h"
@@ -233,12 +234,6 @@ struct va_trace {
     va_TraceMsg(trace_ctx, "") ; \
 } while (0)
 
-/* Prototype declarations (functions defined in va.c) */
-
-void va_errorMessage(const char *msg, ...);
-void va_infoMessage(const char *msg, ...);
-
-int va_parseConfig(char *env, char *env_value);
 
 VAStatus vaBufferInfo(
     VADisplay dpy,

--- a/va/va_trace.h
+++ b/va/va_trace.h
@@ -29,7 +29,7 @@
 extern "C" {
 #endif
 
-extern int trace_flag;
+extern int va_trace_flag;
 
 #define VA_TRACE_FLAG_LOG             0x1
 #define VA_TRACE_FLAG_BUFDATA         0x2
@@ -42,11 +42,11 @@ extern int trace_flag;
                                        VA_TRACE_FLAG_SURFACE_JPEG)
 
 #define VA_TRACE_LOG(trace_func,...)            \
-    if (trace_flag & VA_TRACE_FLAG_LOG) {       \
+    if (va_trace_flag & VA_TRACE_FLAG_LOG) {    \
         trace_func(__VA_ARGS__);                \
     }
 #define VA_TRACE_ALL(trace_func,...)            \
-    if (trace_flag) {                           \
+    if (va_trace_flag) {                        \
         trace_func(__VA_ARGS__);                \
     }
 

--- a/va/wayland/Makefile.am
+++ b/va/wayland/Makefile.am
@@ -59,7 +59,7 @@ protocol_source_h = \
 	$(NULL)
 
 noinst_LTLIBRARIES		= libva_wayland.la
-libva_waylandincludedir		= ${includedir}/va
+libva_waylandincludedir		= ${includedir}/va-@LIBVA_LIB_VERSION@/va
 libva_waylandinclude_HEADERS	= $(source_h)
 libva_wayland_la_SOURCES	= $(source_c) $(protocol_source_c)
 noinst_HEADERS			= $(source_h_priv)

--- a/va/wayland/va_wayland.c
+++ b/va/wayland/va_wayland.c
@@ -32,6 +32,7 @@
 #include "va_wayland_private.h"
 #include "va_backend.h"
 #include "va_backend_wayland.h"
+#include "va_internal.h"
 
 static inline VADriverContextP
 get_driver_context(VADisplay dpy)
@@ -120,11 +121,10 @@ vaGetDisplayWl(struct wl_display *display)
     struct VADriverVTableWayland *vtable;
     unsigned int i;
 
-    pDisplayContext = calloc(1, sizeof(*pDisplayContext));
+    pDisplayContext = va_newDisplayContext();
     if (!pDisplayContext)
         return NULL;
 
-    pDisplayContext->vadpy_magic        = VA_DISPLAY_MAGIC;
     pDisplayContext->vaIsValid          = va_DisplayContextIsValid;
     pDisplayContext->vaDestroy          = va_DisplayContextDestroy;
     pDisplayContext->vaGetDriverName    = va_DisplayContextGetDriverName;

--- a/va/x11/Makefile.am
+++ b/va/x11/Makefile.am
@@ -50,7 +50,7 @@ source_h_priv = \
 	$(NULL)
 
 noinst_LTLIBRARIES		= libva_x11.la	
-libva_x11includedir		= ${includedir}/va
+libva_x11includedir		= ${includedir}/va-@LIBVA_LIB_VERSION@/va
 libva_x11include_HEADERS	= $(source_h)
 libva_x11_la_SOURCES		= $(source_c)
 noinst_HEADERS			= $(source_h_priv)

--- a/va/x11/dri2_util.c
+++ b/va/x11/dri2_util.c
@@ -166,14 +166,14 @@ dri2Close(VADriverContextP ctx)
 {
     struct dri_state *dri_state = (struct dri_state *)ctx->drm_state;
 
-    free_drawable_hashtable(ctx);
+    va_dri_free_drawable_hashtable(ctx);
 
     if (dri_state->base.fd >= 0)
 	close(dri_state->base.fd);
 }
 
 Bool 
-isDRI2Connected(VADriverContextP ctx, char **driver_name)
+va_isDRI2Connected(VADriverContextP ctx, char **driver_name)
 {
     struct dri_state *dri_state = (struct dri_state *)ctx->drm_state;
     int major, minor;

--- a/va/x11/va_dricommon.c
+++ b/va/x11/va_dricommon.c
@@ -81,7 +81,7 @@ do_drawable_hash(VADriverContextP ctx, XID drawable)
 }
 
 void
-free_drawable(VADriverContextP ctx, struct dri_drawable* dri_drawable)
+va_dri_free_drawable(VADriverContextP ctx, struct dri_drawable* dri_drawable)
 {
     struct dri_state *dri_state = (struct dri_state *)ctx->drm_state;
     int i = 0;
@@ -96,7 +96,7 @@ free_drawable(VADriverContextP ctx, struct dri_drawable* dri_drawable)
 }
 
 void
-free_drawable_hashtable(VADriverContextP ctx)
+va_dri_free_drawable_hashtable(VADriverContextP ctx)
 {
     struct dri_state *dri_state = (struct dri_state *)ctx->drm_state;
     int i;
@@ -116,13 +116,13 @@ free_drawable_hashtable(VADriverContextP ctx)
 }
 
 struct dri_drawable *
-dri_get_drawable(VADriverContextP ctx, XID drawable)
+va_dri_get_drawable(VADriverContextP ctx, XID drawable)
 {
     return do_drawable_hash(ctx, drawable);
 }
 
 void 
-dri_swap_buffer(VADriverContextP ctx, struct dri_drawable *dri_drawable)
+va_dri_swap_buffer(VADriverContextP ctx, struct dri_drawable *dri_drawable)
 {
     struct dri_state *dri_state = (struct dri_state *)ctx->drm_state;
 
@@ -130,7 +130,7 @@ dri_swap_buffer(VADriverContextP ctx, struct dri_drawable *dri_drawable)
 }
 
 union dri_buffer *
-dri_get_rendering_buffer(VADriverContextP ctx, struct dri_drawable *dri_drawable)
+va_dri_get_rendering_buffer(VADriverContextP ctx, struct dri_drawable *dri_drawable)
 {
     struct dri_state *dri_state = (struct dri_state *)ctx->drm_state;
     

--- a/va/x11/va_dricommon.h
+++ b/va/x11/va_dricommon.h
@@ -84,11 +84,11 @@ struct dri_state
 #endif
 };
 
-Bool isDRI2Connected(VADriverContextP ctx, char **driver_name);
-void free_drawable(VADriverContextP ctx, struct dri_drawable* dri_drawable);
-void free_drawable_hashtable(VADriverContextP ctx);
-struct dri_drawable *dri_get_drawable(VADriverContextP ctx, XID drawable);
-void dri_swap_buffer(VADriverContextP ctx, struct dri_drawable *dri_drawable);
-union dri_buffer *dri_get_rendering_buffer(VADriverContextP ctx, struct dri_drawable *dri_drawable);
+Bool va_isDRI2Connected(VADriverContextP ctx, char **driver_name);
+void va_dri_free_drawable(VADriverContextP ctx, struct dri_drawable* dri_drawable);
+void va_dri_free_drawable_hashtable(VADriverContextP ctx);
+struct dri_drawable *va_dri_get_drawable(VADriverContextP ctx, XID drawable);
+void va_dri_swap_buffer(VADriverContextP ctx, struct dri_drawable *dri_drawable);
+union dri_buffer *va_dri_get_rendering_buffer(VADriverContextP ctx, struct dri_drawable *dri_drawable);
 
 #endif /* _VA_DRICOMMON_H_ */

--- a/va/x11/va_x11.c
+++ b/va/x11/va_x11.c
@@ -195,8 +195,6 @@ VADisplay vaGetDisplay (
   return dpy;
 }
 
-#define CTX(dpy) (((VADisplayContextP)dpy)->pDriverContext)
-#define CHECK_DISPLAY(dpy) if( !vaDisplayIsValid(dpy) ) { return VA_STATUS_ERROR_INVALID_DISPLAY; }
 
 void va_TracePutSurface (
     VADisplay dpy,

--- a/va/x11/va_x11.c
+++ b/va/x11/va_x11.c
@@ -81,7 +81,7 @@ static VAStatus va_DRI2GetDriverName (
 {
     VADriverContextP ctx = pDisplayContext->pDriverContext;
 
-    if (!isDRI2Connected(ctx, driver_name))
+    if (!va_isDRI2Connected(ctx, driver_name))
         return VA_STATUS_ERROR_UNKNOWN;
 
     return VA_STATUS_SUCCESS;

--- a/va/x11/va_x11.c
+++ b/va/x11/va_x11.c
@@ -26,6 +26,7 @@
 #include "sysdeps.h"
 #include "va.h"
 #include "va_backend.h"
+#include "va_internal.h"
 #include "va_trace.h"
 #include "va_fool.h"
 #include "va_x11.h"
@@ -163,13 +164,11 @@ VADisplay vaGetDisplay (
       /* create new entry */
       VADriverContextP pDriverContext;
       struct dri_state *dri_state;
-      pDisplayContext = calloc(1, sizeof(*pDisplayContext));
+      pDisplayContext = va_newDisplayContext();
       pDriverContext  = calloc(1, sizeof(*pDriverContext));
       dri_state       = calloc(1, sizeof(*dri_state));
       if (pDisplayContext && pDriverContext && dri_state)
       {
-	  pDisplayContext->vadpy_magic = VA_DISPLAY_MAGIC;          
-
 	  pDriverContext->native_dpy       = (void *)native_dpy;
 	  pDriverContext->x11_screen       = XDefaultScreen(native_dpy);
           pDriverContext->display_type     = VA_DISPLAY_X11;

--- a/va/x11/va_x11.c
+++ b/va/x11/va_x11.c
@@ -232,7 +232,7 @@ VAStatus vaPutSurface (
 {
   VADriverContextP ctx;
 
-  if (fool_postp)
+  if (va_fool_postp)
       return VA_STATUS_SUCCESS;
 
   CHECK_DISPLAY(dpy);


### PR DESCRIPTION
i965 will return the I420 in vaQuerySurfaceAttributes, but va.h didn't
add the pre-define fourcc, and will deprecate IYUV because it same as
I420 but most user perfer I420.

Signed-off-by: Jun Zhao <jun.zhao@intel.com>