### PR TITLE
New API/data structures for Flexible Encoding Infrastructure (FEI) Support

### DIFF
--- a/va/Makefile.am
+++ b/va/Makefile.am
@@ -51,6 +51,8 @@ libva_source_h = \
 	va_enc_h264.h		\
 	va_enc_jpeg.h		\
 	va_enc_vp8.h		\
+	va_fei.h    		\
+	va_fei_h264.h		\
 	va_enc_mpeg2.h		\
 	va_enc_vp9.h            \
 	va_tpi.h		\

--- a/va/va.h
+++ b/va/va.h
@@ -230,6 +230,16 @@ typedef struct _VARectangle
     unsigned short height;
 } VARectangle;
 
+/** \brief Generic motion vector data structure. */
+typedef struct _VAMotionVector {
+    /** \mv0[0]: horizontal motion vector for past reference */
+    /** \mv0[1]: vertical motion vector for past reference */
+    /** \mv1[0]: horizontal motion vector for future reference */
+    /** \mv1[1]: vertical motion vector for future reference */
+    int16_t  mv0[2];  /* past reference */
+    int16_t  mv1[2];  /* future reference */
+} VAMotionVector;
+
 /** Type of a message callback, used for both error and info log. */
 typedef void (*vaMessageCallback)(const char *message);
 
@@ -354,6 +364,23 @@ typedef enum
      */
     VAEntrypointEncSliceLP 	= 8,
     VAEntrypointVideoProc       = 10,   /**< Video pre/post-processing. */
+    /**
+     * \brief VAEntrypointFEI
+     *
+     * The purpose of FEI (Flexible Encoding Infrastructure) is to allow applications to
+     * have more controls and trade off quality for speed with their own IPs.
+     * The application can optionally provide input to ENC for extra encode control
+     * and get the output from ENC. Application can chose to modify the ENC
+     * output/PAK input during encoding, but the performance impact is significant.
+     *
+     * On top of the existing buffers for normal encode, there will be
+     * one extra input buffer (VAEncMiscParameterFEIFrameControl) and
+     * three extra output buffers (VAEncFEIMVBufferType, VAEncFEIMBModeBufferType
+     * and VAEncFEIDistortionBufferType) for VAEntrypointFEI entry function.
+     * If separate PAK is set, two extra input buffers
+     * (VAEncFEIMVBufferType, VAEncFEIMBModeBufferType) are needed for PAK input.
+     **/
+    VAEntrypointFEI         = 11,
 } VAEntrypoint;
 
 /** Currently defined configuration attribute types */
@@ -495,6 +522,23 @@ typedef enum
      */
     VAConfigAttribEncRateControlExt   = 26,
 
+    /**
+     * \brief Encode function type for FEI.
+     *
+     * This attribute conveys whether the driver supports different function types for encode.
+     * It can be VA_FEI_FUNCTION_ENC, VA_FEI_FUNCTION_PAK, or VA_FEI_FUNCTION_ENC_PAK. Currently
+     * it is for FEI entry point only.
+     * Default is VA_FEI_FUNCTION_ENC_PAK.
+     */
+    VAConfigAttribFEIFunctionType     = 32,
+    /**
+     * \brief Maximum number of FEI MV predictors. Read-only.
+     *
+     * This attribute determines the maximum number of MV predictors the driver
+     * can support to encode a single frame. 0 means no MV predictor is supported.
+     * Currently it is for FEI entry point only.
+     */
+    VAConfigAttribFEIMVPredictors     = 33,
     /**@}*/
     VAConfigAttribTypeMax
 } VAConfigAttribType;
@@ -1153,6 +1197,14 @@ typedef enum
      * color balance (#VAProcFilterParameterBufferColorBalance), etc.
      */
     VAProcFilterParameterBufferType     = 42,
+    /**
+     * \brief FEI specific buffer types
+     */
+    VAEncFEIMVBufferType                = 43,
+    VAEncFEIMBCodeBufferType            = 44,
+    VAEncFEIDistortionBufferType        = 45,
+    VAEncFEIMBControlBufferType         = 46,
+    VAEncFEIMVPredictorBufferType       = 47,
     VABufferTypeMax
 } VABufferType;
 
@@ -1174,6 +1226,8 @@ typedef enum
     VAEncMiscParameterTypeROI           = 10,
     /** \brief Buffer type used for temporal layer structure */
     VAEncMiscParameterTypeTemporalLayerStructure   = 12,
+    /** \brief Buffer type used for FEI input frame level parameters */
+    VAEncMiscParameterTypeFEIFrameControl = 18,
 } VAEncMiscParameterType;
 
 /** \brief Packed header type. */
@@ -3130,6 +3184,8 @@ typedef struct _VAPictureHEVC
 #include <va/va_enc_mpeg2.h>
 #include <va/va_enc_vp8.h>
 #include <va/va_enc_vp9.h>
+#include <va/va_fei.h>
+#include <va/va_fei_h264.h>
 #include <va/va_vpp.h>
 
 /**@}*/

--- a/va/va.h
+++ b/va/va.h
@@ -1123,6 +1123,15 @@ typedef enum
     VAEncMiscParameterBufferType	= 27,
     VAEncMacroblockParameterBufferType	= 28,
     VAEncMacroblockMapBufferType        = 29,
+
+    /**
+     * \brief Encoding QP buffer
+     *
+     * This buffer contains QP per MB for encoding. Currently
+     * VAEncQPBufferH264 is defined for H.264 encoding, see
+     * #VAEncQPBufferH264 for details
+     */
+    VAEncQPBufferType                   = 30,
 /* Following are video processing buffer types */
     /**
      * \brief Video processing pipeline parameter buffer.

--- a/va/va_enc_h264.h
+++ b/va/va_enc_h264.h
@@ -368,6 +368,15 @@ typedef struct _VAEncPictureParameterBufferH264 {
     } pic_fields;
 } VAEncPictureParameterBufferH264;
 
+typedef struct _VAEncQPBufferH264 {
+    /*
+     * \brief This structure holds QP per 16x16 macroblock. Buffer size shall be
+     * sufficient to fit the slice or frame to be encoded depending on if it is a
+     * slice level or frame level encoding.
+     */
+    uint8_t qp;
+} VAEncQPBufferH264;
+
 /**
  * \brief Slice parameter for H.264 encoding in baseline, main & high profiles.
  *

--- a/va/va_fei.h
+++ b/va/va_fei.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2007-2017 Intel Corporation. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sub license, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the
+ * next paragraph) shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
+ * IN NO EVENT SHALL INTEL AND/OR ITS SUPPLIERS BE LIABLE FOR
+ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * \file va_fei.h
+ * \brief The FEI encoding common API
+ */
+
+#ifndef VA_FEI_H
+#define VA_FEI_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+/**
+ * \brief FEI specific attribute definitions
+ */
+/** @name Attribute values for VAConfigAttribFEIFunctionType
+ *
+ * This is only for VAEntrypointFEI
+ * The desired type should be passed to driver when creating the configuration.
+ * If VA_FEI_FUNCTION_ENC_PAK is set, VA_FEI_FUNCTION_ENC and VA_FEI_FUNCTION_PAK
+ * will be ignored if set also. Combination of VA_FEI_FUNCTION_ENC and VA_FEI_FUNCTION_PAK
+ * is not valid. If  VA_FEI_FUNCTION_ENC is set, there will be no bitstream output.
+ * If VA_FEI_FUNCTION_PAK is set, two extra input buffers for PAK are needed:
+ * VAEncFEIMVBufferType and VAEncFEIMBCodeBufferType.
+ * VA_FEI_FUNCTION_ENC_PAK is recommended for best performance.
+ *
+ **/
+/**@{*/
+/** \brief ENC only is supported */
+#define VA_FEI_FUNCTION_ENC                             0x00000001
+/** \brief PAK only is supported */
+#define VA_FEI_FUNCTION_PAK                             0x00000002
+/** \brief ENC_PAK is supported */
+#define VA_FEI_FUNCTION_ENC_PAK                         0x00000004
+
+/**@}*/
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* VA_FEI_H */

--- a/va/va_fei_h264.h
+++ b/va/va_fei_h264.h
@@ -1,0 +1,325 @@
+/*
+ * Copyright (c) 2007-2017 Intel Corporation. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sub license, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the
+ * next paragraph) shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
+ * IN NO EVENT SHALL INTEL AND/OR ITS SUPPLIERS BE LIABLE FOR
+ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * \file va_fei_h264.h
+ * \brief The FEI encoding H264 special API
+ */
+
+#ifndef VA_FEI_H264_H
+#define VA_FEI_H264_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include "va_fei.h"
+
+/** \brief FEI frame level control buffer for H.264 */
+typedef struct _VAEncMiscParameterFEIFrameControlH264
+{
+    uint32_t      function; /* one of the VAConfigAttribFEIFunctionType values */
+    /** \brief MB (16x16) control input buffer. It is valid only when (mb_input | mb_size_ctrl)
+     * is set to 1. The data in this buffer correspond to the input source. 16x16 MB is in raster scan order,
+     * each MB control data structure is defined by VAEncFEIMBControlH264.
+     * Buffer size shall not be less than the number of 16x16 blocks multiplied by
+     * sizeof(VAEncFEIMBControlH264).
+     * Note: if mb_qp is set, VAEncQPBufferH264 is expected.
+     */
+    VABufferID    mb_ctrl;
+    /** \brief distortion output of MB ENC or ENC_PAK.
+     * Each 16x16 block has one distortion data with VAEncFEIDistortionH264 layout
+     * Buffer size shall not be less than the number of 16x16 blocks multiplied by
+     * sizeof(VAEncFEIDistortionH264).
+     */
+    VABufferID    distortion;
+    /** \brief MVs data output of MB ENC.
+     * Each 16x16 block has one MVs data with layout VAMotionVector
+     * Buffer size shall not be less than the number of 16x16 blocks multiplied by
+     * sizeof(VAMotionVector) * 16.
+     */
+    VABufferID    mv_data;
+    /** \brief MBCode data output of MB ENC.
+     * Each 16x16 block has one MB Code data with layout VAEncFEIMBCodeH264
+     * Buffer size shall not be less than the number of 16x16 blocks multiplied by
+     * sizeof(VAEncFEIMBCodeH264).
+     */
+    VABufferID    mb_code_data;
+    /** \brief QP input buffer with layout VAEncQPBufferH264. It is valid only when mb_qp is set to 1.
+     * The data in this buffer correspond to the input source.
+     * One QP per 16x16 block in raster scan order, each QP is a signed char (8-bit) value.
+     **/
+    VABufferID    qp;
+    /** \brief MV predictor. It is valid only when mv_predictor_enable is set to 1.
+     * Each 16x16 block has one or more pair of motion vectors and the corresponding
+     * reference indexes as defined by VAEncFEIMVPredictorH264. 16x16 block is in raster scan order.
+     * Buffer size shall not be less than the number of 16x16 blocks multiplied by
+     * sizeof(VAEncFEIMVPredictorH264). */
+    VABufferID    mv_predictor;
+
+    /** \brief number of MV predictors. It must not be greater than maximum supported MV predictor. */
+    uint32_t      num_mv_predictors_l0      : 16;
+    uint32_t      num_mv_predictors_l1      : 16;
+
+    /** \brief motion search method definition
+     * 0: default value, diamond search
+     * 1: full search
+     * 2: diamond search
+     **/
+    uint32_t      search_path               : 8;
+    /** \brief maximum number of Search Units, valid range is [1, 63] */
+    uint32_t      len_sp                    : 8;
+    uint32_t      reserved0	                : 16;
+
+    uint32_t      sub_mb_part_mask          : 7;
+    uint32_t      intra_part_mask           : 5;
+    uint32_t      multi_pred_l0             : 1;
+    uint32_t      multi_pred_l1             : 1;
+    uint32_t      sub_pel_mode              : 2;
+    uint32_t      inter_sad 	            : 2;
+    uint32_t      intra_sad                 : 2;
+    uint32_t      distortion_type           : 1;
+    uint32_t      repartition_check_enable  : 1;
+    uint32_t      adaptive_search           : 1;
+    uint32_t      mv_predictor_enable       : 1;
+    uint32_t      mb_qp                     : 1;
+    uint32_t      mb_input                  : 1;
+    uint32_t      mb_size_ctrl              : 1;
+    uint32_t      colocated_mb_distortion   : 1;
+    uint32_t      reserved1	                : 4;
+
+    /** \brief motion search window(ref_width * ref_height) */
+    uint32_t      ref_width                 : 8;
+    uint32_t      ref_height                : 8;
+    /** \brief predefined motion search windows. If selected, len_sp, window(ref_width * ref_eight)
+     * and search_path setting are ignored.
+     * 0: not use predefined search window
+     * 1: Tiny, len_sp=4, 24x24 window and diamond search
+     * 2: Small, len_sp=9, 28x28 window and diamond search
+     * 3: Diamond, len_sp=16, 48x40 window and diamond search
+     * 4: Large Diamond, len_sp=32, 48x40 window and diamond search
+     * 5: Exhaustive, len_sp=48, 48x40 window and full search
+     * 6: Extend Diamond, len_sp=16, 64x40 window and diamond search
+     * 7: Extend Large Diamond, len_sp=32, 64x40 window and diamond search
+     * 8: Extend Exhaustive, len_sp=48, 64x40 window and full search
+     **/
+    uint32_t      search_window             : 4;
+    uint32_t      reserved2                 : 12;
+
+    /** \brief max frame size control with multi passes QP setting */
+    uint32_t      max_frame_size;
+    /** \brief number of passes, every pass has different QP */
+    uint32_t      num_passes;
+    /** \brief delta QP list for every pass */
+    uint8_t       *delta_qp;
+    uint32_t      reserved3[2];
+} VAEncMiscParameterFEIFrameControlH264;
+
+/** \brief FEI MB level control data structure */
+typedef struct _VAEncFEIMBControlH264
+{
+    /** \brief when set, correposndent MB is coded as intra */
+    uint32_t force_to_intra                : 1;
+    /** \brief when set, correposndent MB is coded as skip */
+    uint32_t force_to_skip                 : 1;
+    uint32_t force_to_nonskip              : 1;
+    uint32_t enable_direct_bias_adjustment : 1;
+    uint32_t enable_motion_bias_adjustment : 1;
+    uint32_t ext_mv_cost_scaling_factor    : 3;
+    uint32_t reserved0                     : 24;
+
+    uint32_t reserved1;
+
+    uint32_t reserved2;
+
+    /** \brief when mb_size_ctrl is set, size here is used to budget accumulatively. Set to 0xFF if don't care. */
+    uint32_t reserved3                     : 16;
+    uint32_t target_size_in_word           : 8;
+    uint32_t max_size_in_word              : 8;
+} VAEncFEIMBControlH264;
+
+
+/** \brief Application can use this definition as reference to allocate the buffer
+ * based on MaxNumPredictor returned from attribute VAConfigAttribFEIMVPredictors query.
+ **/
+typedef struct _VAEncFEIMVPredictorH264
+{
+    /** \brief Reference index corresponding to the entry of RefPicList0 & RefPicList1 in VAEncSliceParameterBufferH264.
+     * Note that RefPicList0 & RefPicList1 needs to be the same for all slices.
+     * ref_idx_l0_x : index to RefPicList0; ref_idx_l1_x : index to RefPicList1; x : 0 - MaxNumPredictor.
+     **/
+    struct {
+        uint8_t   ref_idx_l0    : 4;
+        uint8_t   ref_idx_l1    : 4;
+    } ref_idx[4]; /* index is predictor number */
+    uint32_t reserved;
+    /** \brief MV. MaxNumPredictor must be the returned value from attribute VAConfigAttribFEIMVPredictors query.
+     * Even application doesn't use the maximum predictors, the VAFEIMVPredictorH264 structure size
+     * has to be defined as maximum so each MB can be at a fixed location.
+     * Note that 0x8000 must be used for correspondent intra block.
+     **/
+    VAMotionVector mv[4]; /* MaxNumPredictor is 4 */
+} VAEncFEIMVPredictorH264;
+
+/** \brief FEI output */
+/**
+ * Motion vector output is per 4x4 block. For each 4x4 block there is a pair of MVs
+ * for RefPicList0 and RefPicList1 and each MV is 4 bytes including horizontal and vertical directions.
+ * Depending on Subblock partition, for the shape that is not 4x4, the MV is replicated
+ * so each 4x4 block has a pair of MVs. The 16x16 block has 32 MVs (128 bytes).
+ * 0x8000 is used for correspondent intra block. The 16x16 block is in raster scan order,
+ * within the 16x16 block, each 4x4 block MV is ordered as below in memory.
+ * The buffer size shall be greater than or equal to the number of 16x16 blocks multiplied by 128 bytes.
+ * Note that, when separate ENC and PAK is enabled, the exact layout of this buffer is needed for PAK input.
+ * App can reuse this buffer, or copy to a different buffer as PAK input.
+ * Layout is defined as Generic motion vector data structure VAMotionVector
+ *                      16x16 Block
+ *        -----------------------------------------
+ *        |    1    |    2    |    5    |    6    |
+ *        -----------------------------------------
+ *        |    3    |    4    |    7    |    8    |
+ *        -----------------------------------------
+ *        |    9    |    10   |    13   |    14   |
+ *        -----------------------------------------
+ *        |    11   |    12   |    15   |    16   |
+ *        -----------------------------------------
+ **/
+
+/** \brief VAEncFEIMBCodeH264 defines the data structure for VAEncFEIMBCodeBufferType per 16x16 MB block.
+ * it is output buffer of ENC and ENC_PAK modes, it's also input buffer of PAK mode.
+ * The 16x16 block is in raster scan order. Buffer size shall not be less than the number of 16x16 blocks
+ * multiplied by sizeof(VAEncFEIMBCodeH264). Note that, when separate ENC and PAK is enabled,
+ * the exact layout of this buffer is needed for PAK input. App can reuse this buffer,
+ * or copy to a different buffer as PAK input, reserved elements must not be modified when used as PAK input.
+ **/
+typedef struct _VAEncFEIMBCodeH264
+{
+    //DWORD  0~2
+    uint32_t    reserved0[3];
+
+    //DWORD  3
+    uint32_t    inter_mb_mode            : 2;
+    uint32_t    mb_skip_flag             : 1;
+    uint32_t    reserved1                : 1;
+    uint32_t    intra_mb_mode            : 2;
+    uint32_t    reserved2                : 1;
+    uint32_t    field_mb_polarity_flag   : 1;
+    uint32_t    mb_type                  : 5;
+    uint32_t    intra_mb_flag	         : 1;
+    uint32_t    field_mb_flag            : 1;
+    uint32_t    transform8x8_flag        : 1;
+    uint32_t    reserved3                : 1;
+    uint32_t    dc_block_coded_cr_flag   : 1;
+    uint32_t    dc_block_coded_cb_flag   : 1;
+    uint32_t    dc_block_coded_y_flag    : 1;
+    uint32_t    reserved4                : 12;
+
+    //DWORD 4
+    uint32_t    horz_origin              : 8;
+    uint32_t    vert_origin              : 8;
+    uint32_t    cbp_y                    : 16;
+
+    //DWORD 5
+    uint32_t    cbp_cb                   : 16;
+    uint32_t    cbp_cr                   : 16;
+
+    //DWORD 6
+    uint32_t    qp_prime_y               : 8;
+    uint32_t    reserved5                : 17;
+    uint32_t    mb_skip_conv_disable     : 1;
+    uint32_t    is_last_mb               : 1;
+    uint32_t    enable_coefficient_clamp : 1;
+    uint32_t    direct8x8_pattern        : 4;
+
+    //DWORD 7 8 and 9
+    union
+    {
+        /* Intra MBs */
+        struct
+        {
+            uint32_t   luma_intra_pred_modes0 : 16;
+            uint32_t   luma_intra_pred_modes1 : 16;
+
+            uint32_t   luma_intra_pred_modes2 : 16;
+            uint32_t   luma_intra_pred_modes3 : 16;
+
+            uint32_t   chroma_intra_pred_mode : 2;
+            uint32_t   intra_pred_avail_flag  : 5;
+            uint32_t   intra_pred_avail_flagF : 1;
+            uint32_t   reserved6              : 24;
+        } intra_mb;
+
+        /* Inter MBs */
+        struct
+        {
+            uint32_t   sub_mb_shapes          : 8;
+            uint32_t   sub_mb_pred_modes      : 8;
+            uint32_t   reserved7              : 16;
+
+            uint32_t   ref_idx_l0_0           : 8;
+            uint32_t   ref_idx_l0_1           : 8;
+            uint32_t   ref_idx_l0_2           : 8;
+            uint32_t   ref_idx_l0_3           : 8;
+
+            uint32_t   ref_idx_l1_0           : 8;
+            uint32_t   ref_idx_l1_1           : 8;
+            uint32_t   ref_idx_l1_2           : 8;
+            uint32_t   ref_idx_l1_3           : 8;
+        } inter_mb;
+    } mb_mode;
+
+    //DWORD 10
+    uint32_t   reserved8                 : 16;
+    uint32_t   target_size_in_word       : 8;
+    uint32_t   max_size_in_word          : 8;
+
+    //DWORD 11~14
+    uint32_t   reserved9[4];
+
+    //DWORD 15
+    uint32_t   reserved10;
+} VAEncFEIMBCodeH264;        // 64 bytes
+
+/** \brief VAEncFEIDistortionH264 defines the data structure for VAEncFEIDistortionBufferType per 16x16 MB block.
+ * It is output buffer of ENC and ENC_PAK modes, The 16x16 block is in raster scan order.
+ * Buffer size shall not be less than the number of 16x16 blocks multiple by sizeof(VAEncFEIDistortionH264).
+ **/
+typedef struct _VAEncFEIDistortionH264 {
+    /** \brief Inter-prediction-distortion associated with motion vector i (co-located with subblock_4x4_i).
+     * Its meaning is determined by sub-shape. It must be zero if the corresponding sub-shape is not chosen.
+     **/
+    uint16_t    inter_distortion[16];
+    uint32_t    best_inter_distortion     : 16;
+    uint32_t    best_intra_distortion     : 16;
+    uint32_t    colocated_mb_distortion   : 16;
+    uint32_t    reserved0                 : 16;
+    uint32_t    reserved1[2];
+} VAEncFEIDistortionH264;    // 48 bytes
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* VA_FEI_H264_H */


### PR DESCRIPTION
This PRs adds the follows new API / data structures

* Encoding QP buffer: user can specify the QP for each MB and use VAEncQPBufferType to pass the QP buffer to the driver, this QP buffer can be used for FEI and non-FEI.

* VAEntrypointFEI: Add a new entrypoint and related data structures.

VAEntrypointFEI in this PR is a part of https://github.com/01org/libva/pull/83