### PR TITLE
Fix deprecated warning

### DIFF
--- a/va/va_enc_h264.h
+++ b/va/va_enc_h264.h
@@ -122,7 +122,7 @@ typedef enum {
      * \c VA_ENC_PACKED_HEADER_RAW_DATA to pass the corresponding packed
      * SEI header data buffer to the driver
      */
-    VAEncPackedHeaderH264_SEI va_deprecated_enum  = (VAEncPackedHeaderMiscMask | 1),
+    VAEncPackedHeaderH264_SEI va_deprecated_enum  = (0x80000000 | 1),
 } VAEncPackedHeaderTypeH264;
 
 /**

--- a/va/va_enc_hevc.h
+++ b/va/va_enc_hevc.h
@@ -134,7 +134,7 @@ typedef enum {
      * \c VA_ENC_PACKED_HEADER_RAW_DATA to pass the corresponding packed
      * SEI header data buffer to the driver
      */
-    VAEncPackedHeaderHEVC_SEI  va_deprecated_enum = (VAEncPackedHeaderMiscMask | 1),
+    VAEncPackedHeaderHEVC_SEI  va_deprecated_enum = (0x80000000 | 1),
 } VAEncPackedHeaderTypeHEVC;
 
 /**

--- a/va/va_fool.c
+++ b/va/va_fool.c
@@ -187,8 +187,7 @@ int va_FoolCreateConfig(
         fool_ctx->enabled = 1;
     else if ((va_fool_codec & VA_FOOL_FLAG_ENCODE) && (entrypoint == VAEntrypointEncSlice)) {
         /* H264 is desired */
-        if (((profile == VAProfileH264Baseline ||
-              profile == VAProfileH264Main ||
+        if (((profile == VAProfileH264Main ||
               profile == VAProfileH264High ||
               profile == VAProfileH264ConstrainedBaseline)) &&
             strstr(fool_ctx->fn_enc, "h264"))

--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -4791,7 +4791,6 @@ void va_TraceRenderPicture(
                 va_TraceMPEG4Buf(dpy, context, buffers[i], type, size, num_elements, pbuf + size*j);
             }
             break;
-        case VAProfileH264Baseline:
         case VAProfileH264Main:
         case VAProfileH264High:
         case VAProfileH264ConstrainedBaseline:


### PR DESCRIPTION
enums marked as deprecated should not be used any more.

Signed-off-by: Xiang, Haihao <haihao.xiang@intel.com>