### PR TITLE
Statistics function for FEI and non-FEI

### DIFF
--- a/va/va.h
+++ b/va/va.h
@@ -401,6 +401,23 @@ typedef enum
      * (VAEncFEIMVBufferType, VAEncFEIMBModeBufferType) are needed for PAK input.
      **/
     VAEntrypointFEI         = 11,
+    /**
+     * \brief VAEntrypointStats
+     *
+     * A pre-processing function for getting some statistics and motion vectors is added,
+     * and some extra controls for Encode pipeline are provided. The application can
+     * optionally call the statistics function to get motion vectors and statistics like
+     * variances, distortions before calling Encode function via this entry point.
+     *
+     * Checking whether Statistics is supported can be performed with vaQueryConfigEntrypoints().
+     * If Statistics entry point is supported, then the list of returned entry-points will
+     * include #VAEntrypointStats. Supported pixel format, maximum resolution and statistics
+     * specific attributes can be obtained via normal attribute query. One input buffer
+     * (VAStatsStatisticsParameterBufferType) and one or two output buffers
+     * (VAStatsStatisticsBufferType, VAStatsStatisticsBottomFieldBufferType (for interlace only)
+     * and VAStatsMVBufferType) are needed for this entry point.
+     **/
+    VAEntrypointStats       = 12,
 } VAEntrypoint;
 
 /** Currently defined configuration attribute types */
@@ -678,6 +695,14 @@ typedef enum
      * Currently it is for FEI entry point only.
      */
     VAConfigAttribFEIMVPredictors     = 33,
+    /**
+     * \brief Statistics attribute. Read-only.
+     *
+     * This attribute exposes a number of capabilities of the VAEntrypointStats entry
+     * point. The attribute value is partitioned into fields as defined in the
+     * VAConfigAttribValStats union. Currently it is for VAEntrypointStats only.
+     */
+    VAConfigAttribStats               = 34,
      /**
      * \brief Tile Support Attribute. Read-only.
      *
@@ -1550,6 +1575,13 @@ typedef enum
     VAEncFEIDistortionBufferType        = 45,
     VAEncFEIMBControlBufferType         = 46,
     VAEncFEIMVPredictorBufferType       = 47,
+    VAStatsStatisticsParameterBufferType = 48,
+    /** \brief Statistics output for VAEntrypointStats progressive and top field of interlaced case*/
+    VAStatsStatisticsBufferType         = 49,
+    /** \brief Statistics output for VAEntrypointStats bottom field of interlaced case*/
+    VAStatsStatisticsBottomFieldBufferType = 50,
+    VAStatsMVBufferType                 = 51,
+    VAStatsMVPredictorBufferType        = 52,
     /** Force MB's to be non skip for encode.it's per-mb control buffer, The width of the MB map
      * Surface is (width of the Picture in MB unit) * 1 byte, multiple of 64 bytes.
      * The height is (height of the picture in MB unit). The picture is either

--- a/va/va_fei.h
+++ b/va/va_fei.h
@@ -61,6 +61,102 @@ extern "C" {
 
 /**@}*/
 
+/** \brief Attribute value for VAConfigAttribStats */
+typedef union _VAConfigAttribValStats {
+    struct {
+        /** \brief Max number of past reference frames that are supported. */
+        uint32_t    max_num_past_references   : 4;
+        /** \brief Max number of future reference frames that are supported. */
+        uint32_t    max_num_future_references : 4;
+        /** \brief Number of supported output buffers for VAStatsStatisticsParameter->outputs */
+        uint32_t    num_outputs               : 3;
+        /** \brief Interlaced content is supported */
+        uint32_t    interlaced                : 1;
+        uint32_t    reserved                  : 20;
+    } bits;
+    uint32_t value;
+} VAConfigAttribValStats;
+
+typedef struct _VAPictureStats
+{
+    VASurfaceID picture_id;
+    /*
+     * see flags below.
+     */
+    uint32_t flags;
+} VAPictureStats;
+/* flags in VAPictureStats could be one of the following */
+#define VA_PICTURE_STATS_INVALID                   0x00000001
+#define VA_PICTURE_STATS_PROGRESSIVE               0x00000000
+#define VA_PICTURE_STATS_TOP_FIELD                 0x00000002
+#define VA_PICTURE_STATS_BOTTOM_FIELD              0x00000004
+/** \brief picutre surface content updated indicator.
+ * The picture surface content is updated, it means temporary buffer like downscaled pixel data in driver
+ * internal needs be forced freshing
+ **/
+#define VA_PICTURE_STATS_CONTENT_UPDATED           0x00000010
+
+/** \brief Motion Vector and Statistics frame level controls.
+ * common part VAStatsStatisticsParameterBufferType for a MB or CTB
+ **/
+typedef struct _VAStatsStatisticsParameter
+{
+    /** \brief Source surface ID.  */
+    VAPictureStats  input;
+
+    /** \brief Past reference surface ID pointer.  */
+    VAPictureStats  *past_references;
+
+    /** \brief Past reference surface number  */
+    uint32_t        num_past_references;
+
+    /** \brief Statistics output for past reference surface.
+     * Only enabling statistics output for past reference picture when *past_ref_stat_buf is a valid
+     * VABufferID, it is needed in case app wants statistics data of both reference and current pictures
+     * in very special use cases for better performance.
+     * The output layout is defined by VAStatsStatisticsBufferType(for progressive and top field of
+     * interlaced case) and VAStatsStatisticsBottomFieldBufferType(only for interlaced case), only
+     * pixel_average_16x16/pixel_average_8x8 and variance_16x16/variance_8x8 data are valid.
+     **/
+    VABufferID      *past_ref_stat_buf;
+
+    /** \brief Future reference surface ID pointer.  */
+    VAPictureStats  *future_references;
+
+    /** \brief Future reference surface number  */
+    uint32_t        num_future_references;
+
+    /** \brief Statistics output for future reference surface.
+     * Only enabling statistics output for future reference picture when *past_ref_stat_buf is a valid
+     * VABufferID, it is needed in case app wants statistics data of both reference and current pictures
+     * in very special use cases for better performance.
+     * The output layout is defined by VAStatsStatisticsBufferType(for progressive and top field of
+     * interlaced case) and VAStatsStatisticsBottomFieldBufferType(only for interlaced case), only
+     * pixel_average_16x16/pixel_average_8x8 and variance_16x16/variance_8x8 data are valid.
+     **/
+    VABufferID      *future_ref_stat_buf;
+
+    /** \brief ID of the output buffer.
+     * The number of outputs is determined by below DisableMVOutput and DisableStatisticsOutput.
+     * The output layout is defined by VAStatsMVBufferType, VAStatsStatisticsBufferType(for progressive and
+     * top field of interlaced case) and VAStatsStatisticsBottomFieldBufferType(only for interlaced case).
+     **/
+    VABufferID      *outputs;
+
+    /** \brief MV predictor. It is valid only when mv_predictor_ctrl is not 0.
+     * Each block has a pair of MVs, one for past and one for future reference
+     * as defined by VAMotionVector. The block is in raster scan order.
+     * Buffer size shall not be less than the number of blocks multiplied by sizeof(VAMotionVector).
+     **/
+    VABufferID      mv_predictor;
+
+    /** \brief QP input buffer. It is valid only when mb_qp is set to 1.
+     * The data in this buffer correspond to the input source.
+     * One QP per MB or CTB block in raster scan order, each QP is a signed char (8-bit) value.
+     **/
+    VABufferID      qp;
+} VAStatsStatisticsParameter;
+
 #ifdef __cplusplus
 }
 #endif

--- a/va/va_fei_h264.h
+++ b/va/va_fei_h264.h
@@ -318,6 +318,137 @@ typedef struct _VAEncFEIDistortionH264 {
     uint32_t    reserved1[2];
 } VAEncFEIDistortionH264;    // 48 bytes
 
+/** \brief Motion Vector and Statistics frame level controls.
+ * VAStatsStatisticsParameterBufferType for H264 16x16 block
+ **/
+typedef struct _VAStatsStatisticsParameterH264
+{
+   VAStatsStatisticsParameter stats_params;
+
+    uint32_t    frame_qp                    : 8;
+    /** \brief length of search path */
+    uint32_t    len_sp                      : 8;
+    /** \brief motion search method definition
+     * 0: default value, diamond search
+     * 1: full search
+     * 2: diamond search
+     **/
+    uint32_t    search_path                 : 8;
+    uint32_t    reserved0                   : 8;
+
+    uint32_t    sub_mb_part_mask            : 7;
+    /** \brief sub pixel mode definition
+     * 00b: integer mode searching
+     * 01b: half-pel mode searching
+     * 10b: reserved
+     * 11b: quarter-pel mode searching
+     **/
+    uint32_t    sub_pel_mode                : 2;
+    /** \brief distortion measure adjustment for inter search SAD comparison
+     * 00b: none
+     * 01b: reserved
+     * 10b: Haar transform adjusted
+     * 11b: reserved
+     **/
+    uint32_t    inter_sad                   : 2;
+    /** \brief distortion measure adjustment for intra search SAD comparison
+     * 00b: none
+     * 01b: reserved
+     * 10b: Haar transform adjusted
+     * 11b: reserved
+     **/
+    uint32_t    intra_sad                   : 2;
+    uint32_t    adaptive_search	            : 1;
+    /** \brief indicate if future or/and past MV in mv_predictor buffer is valid.
+     * 0: MV predictor disabled
+     * 1: MV predictor enabled for past reference
+     * 2: MV predictor enabled for future reference
+     * 3: MV predictor enabled for both past and future references
+     **/
+    uint32_t    mv_predictor_ctrl           : 3;
+    uint32_t    mb_qp                       : 1;
+    /** \brief forward transform enable
+     * 0: disable
+     * 1: enable, needs frame_qp or mb_qp input for transform
+     **/
+    uint32_t    ft_enable                   : 1;
+    /** \brief luma intra mode partition mask
+     * xxxx1: luma_intra_16x16 disabled
+     * xxx1x: luma_intra_8x8 disabled
+     * xx1xx: luma_intra_4x4 disabled
+     * xx111: intra prediction is disabled
+     **/
+    uint32_t    intra_part_mask             : 5;
+    uint32_t    reserved1                   : 8;
+
+    /** \brief motion search window(ref_width * ref_height) */
+    uint32_t    ref_width                   : 8;
+    uint32_t    ref_height                  : 8;
+    /** \brief predefined motion search windows. If selected, len_sp, window(ref_width * ref_eight)
+     * and search_path setting are ignored.
+     * 0: not use predefined search window
+     * 1: Tiny, len_sp=4, 24x24 window and diamond search
+     * 2: Small, len_sp=9, 28x28 window and diamond search
+     * 3: Diamond, len_sp=16, 48x40 window and diamond search
+     * 4: Large Diamond, len_sp=32, 48x40 window and diamond search
+     * 5: Exhaustive, len_sp=48, 48x40 window and full search
+     * 6: Extend Diamond, len_sp=16, 64x40 window and diamond search
+     * 7: Extend Large Diamond, len_sp=32, 64x40 window and diamond search
+     * 8: Extend Exhaustive, len_sp=48, 64x40 window and full search
+     **/
+    uint32_t    search_window               : 4;
+    uint32_t    reserved2                   : 12;
+
+    /** \brief MVOutput. When set to 1, MV output is NOT provided */
+    uint32_t	disable_mv_output           : 1;
+    /** \brief StatisticsOutput. When set to 1, Statistics output is NOT provided. */
+    uint32_t    disable_statistics_output   : 1;
+    /** \brief block 8x8 data enabling in statistics output */
+    uint32_t    enable_8x8_statistics       : 1;
+    uint32_t    reserved3                   : 29;
+    uint32_t    reserved4[2];
+} VAStatsStatisticsParameterH264;
+
+/** \brief VAStatsStatisticsH264. H264 Statistics buffer layout for VAStatsStatisticsBufferType
+ * and VAStatsStatisticsBottomFieldBufferType(for interlaced only).
+ * Statistics output is per 16x16 block. Data structure per 16x16 block is defined below.
+ * The 16x16 block is in raster scan order. The buffer size shall be greater than or equal to
+ * the number of 16x16 blocks multiplied by sizeof(VAStatsStatisticsH264).
+ **/
+typedef struct _VAStatsStatisticsH264
+{
+    /** \brief past reference  */
+    uint32_t    best_inter_distortion0 : 16;
+    uint32_t    inter_mode0            : 16;
+
+    /** \brief future reference  */
+    uint32_t    best_inter_distortion1 : 16;
+    uint32_t    inter_mode1            : 16;
+
+    uint32_t    best_intra_distortion  : 16;
+    uint32_t    intra_mode             : 16;
+
+    uint32_t    num_non_zero_coef      : 16;
+    uint32_t    reserved0              : 16;
+
+    uint32_t    sum_coef;
+
+    /** \brief DWORD 5 flat info **/
+    uint32_t    mb_is_flat             : 1;
+    uint32_t    reserved1              : 31;
+
+    /** \brief DWORD 6 variance for block16x16**/
+    uint32_t    variance_16x16;
+    /** \brief DWORD 7 ~ 10, variance for block8x8 **/
+    uint32_t    variance_8x8[4];
+
+    /** \brief DWORD 11 pixel_average for block16x16 **/
+    uint32_t    pixel_average_16x16;
+    /** \brief DWORD 12 ~ 15, pixel_average for block8x8 **/
+    uint32_t    pixel_average_8x8[4];
+} VAStatsStatisticsH264;  // 64 bytes
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/va/va_str.c
+++ b/va/va_str.c
@@ -71,6 +71,7 @@ const char *vaEntrypointStr(VAEntrypoint entrypoint)
     TOSTR(VAEntrypointEncSliceLP);
     TOSTR(VAEntrypointVideoProc);
     TOSTR(VAEntrypointFEI);
+    TOSTR(VAEntrypointStats);
     }
     return "<unknown entrypoint>";
 }
@@ -112,6 +113,7 @@ const char *vaConfigAttribTypeStr(VAConfigAttribType configAttribType)
     TOSTR(VAConfigAttribEncTileSupport);
     TOSTR(VAConfigAttribCustomRoundingControl);
     TOSTR(VAConfigAttribQPBlockSize);
+    TOSTR(VAConfigAttribStats);
     case VAConfigAttribTypeMax: break;
     }
     return "<unknown config attribute type>";
@@ -153,6 +155,11 @@ const char *vaBufferTypeStr(VABufferType bufferType)
     TOSTR(VAEncFEIMVPredictorBufferType);
     TOSTR(VAEncMacroblockDisableSkipMapBufferType);
     TOSTR(VADecodeStreamoutBufferType);
+    TOSTR(VAStatsStatisticsParameterBufferType);
+    TOSTR(VAStatsStatisticsBufferType);
+    TOSTR(VAStatsStatisticsBottomFieldBufferType);
+    TOSTR(VAStatsMVBufferType);
+    TOSTR(VAStatsMVPredictorBufferType);
     case VABufferTypeMax: break;
     }
     return "<unknown buffer type>";


### PR DESCRIPTION
A pre-processing function for getting some statistics and motion vectors
is added, and some extra controls for Encode pipeline are provided. The
application can optionally call the statistics function to get motion
vectors and statistics like variances, distortions before calling Encode
function via this entry point.

Signed-off-by: Kelvin Hu <kelvin.hu@intel.com>
Signed-off-by: Jonathan Bian <jonathan.bian@intel.com>
Signed-off-by: Xiang, Haihao <haihao.xiang@intel.com>
Signed-off-by: Sreerenj Balachandran <sreerenj.balachandran@intel.com>
Signed-off-by: Zhong Li <zhong.li@intel.com>
Signed-off-by: Daniel Charles <daniel.charles@intel.com>