### PR TITLE
Use a flexible array member

### DIFF
--- a/va/va.h
+++ b/va/va.h
@@ -1281,7 +1281,7 @@ typedef struct _VAEncPackedHeaderParameterBuffer {
 typedef struct _VAEncMiscParameterBuffer
 {
     VAEncMiscParameterType type;
-    unsigned int data[0];
+    unsigned int data[];
 } VAEncMiscParameterBuffer;
 
 /** \brief Temporal layer Structure*/


### PR DESCRIPTION
ISO C/C++ forbids zero-size array, but flexible array member is
supported since C99.

This fixes https://github.com/01org/libva/issues/76

Signed-off-by: Xiang, Haihao <haihao.xiang@intel.com>