### PR TITLE
Add reserved bytes to most structures

### DIFF
--- a/va/va.h
+++ b/va/va.h
@@ -231,6 +231,12 @@ typedef int VAStatus;	/** Return status type from functions */
 #define VA_FILTER_SCALING_NL_ANAMORPHIC 0x00000300
 #define VA_FILTER_SCALING_MASK          0x00000f00
 
+/** Padding size in 4-bytes */
+#define VA_PADDING_LOW          4
+#define VA_PADDING_MEDIUM       8
+#define VA_PADDING_HIGH         16
+#define VA_PADDING_LARGE        32
+
 /**
  * Returns a short english description of error_status
  */
@@ -1306,6 +1312,9 @@ typedef struct _VAEncPackedHeaderParameterBuffer {
     uint32_t                bit_length;
     /** \brief Flag: buffer contains start code emulation prevention bytes? */
     uint8_t               has_emulation_bytes;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncPackedHeaderParameterBuffer;
 
 /**
@@ -1345,6 +1354,9 @@ typedef struct _VAEncMiscParameterTemporalLayerStructure
      * ids for frames starting from the 2nd frame.
      */
     uint32_t layer_id[32];
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncMiscParameterTemporalLayerStructure;
 
 
@@ -1378,10 +1390,14 @@ typedef struct _VAEncMiscParameterRateControl
              * The temporal layer that the rate control parameters are specified for.
              */
             uint32_t temporal_id : 8;
+            /** \brief Reserved for future use, must be zero */
             uint32_t reserved : 17;
         } bits;
         uint32_t value;
     } rc_flags;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_MEDIUM];
 } VAEncMiscParameterRateControl;
 
 typedef struct _VAEncMiscParameterFrameRate
@@ -1417,6 +1433,9 @@ typedef struct _VAEncMiscParameterFrameRate
          } bits;
          uint32_t value;
      } framerate_flags;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncMiscParameterFrameRate;
 
 /**
@@ -1427,6 +1446,9 @@ typedef struct _VAEncMiscParameterFrameRate
 typedef struct _VAEncMiscParameterMaxSliceSize
 {
     uint32_t max_slice_size;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncMiscParameterMaxSliceSize;
 
 typedef struct _VAEncMiscParameterAIR
@@ -1434,12 +1456,18 @@ typedef struct _VAEncMiscParameterAIR
     uint32_t air_num_mbs;
     uint32_t air_threshold;
     uint32_t air_auto; /* if set to 1 then hardware auto-tune the AIR threshold */
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncMiscParameterAIR;
 
 typedef struct _VAEncMiscParameterHRD
 {
     uint32_t initial_buffer_fullness;       /* in bits */
     uint32_t buffer_size;                   /* in bits */
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncMiscParameterHRD;
 
 /**
@@ -1456,6 +1484,9 @@ typedef struct _VAEncMiscParameterBufferMaxFrameSize {
     VAEncMiscParameterType      type;
     /** \brief Maximum size of a frame (in bits). */
     uint32_t                max_frame_size;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncMiscParameterBufferMaxFrameSize;
 
 /**
@@ -1474,6 +1505,9 @@ typedef struct _VAEncMiscParameterBufferQualityLevel {
      * level is used.
      */
     uint32_t                quality_level;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncMiscParameterBufferQualityLevel;
 
 /**
@@ -1498,6 +1532,9 @@ typedef struct _VAEncMiscParameterSkipFrame {
     /** \brief When skip_frame_flag = 1, the size of the skipped frames in bits.   When skip_frame_flag = 2, 
       * the size of the current skipped frame that is to be packed/encrypted in bits. */
     uint32_t                size_skip_frames;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncMiscParameterSkipFrame;
 
 /**
@@ -1568,6 +1605,9 @@ typedef struct _VAEncMiscParameterBufferROI {
         } bits;
         uint32_t value;
     } roi_flags;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncMiscParameterBufferROI;
 
 /**
@@ -1628,6 +1668,9 @@ typedef struct _VAHuffmanTableBufferJPEGBaseline {
         uint8_t   pad[2];
         /**@}*/
     }                   huffman_table[2];
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAHuffmanTableBufferJPEGBaseline;
 
 /****************************
@@ -1666,6 +1709,9 @@ typedef struct _VAPictureParameterBufferMPEG2
         } bits;
         uint32_t value;
     } picture_coding_extension;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAPictureParameterBufferMPEG2;
 
 /** MPEG-2 Inverse Quantization Matrix Buffer */
@@ -1687,6 +1733,9 @@ typedef struct _VAIQMatrixBufferMPEG2
     uint8_t chroma_intra_quantiser_matrix[64];
     /** \brief Chroma non-intra matrix, in zig-zag scan order. */
     uint8_t chroma_non_intra_quantiser_matrix[64];
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAIQMatrixBufferMPEG2;
 
 /** MPEG-2 Slice Parameter Buffer */
@@ -1700,6 +1749,9 @@ typedef struct _VASliceParameterBufferMPEG2
     uint32_t slice_vertical_position;
     int32_t quantiser_scale_code;
     int32_t intra_slice_flag;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VASliceParameterBufferMPEG2;
 
 /** MPEG-2 Macroblock Parameter Buffer */
@@ -1739,6 +1791,9 @@ typedef struct _VAMacroblockParameterBufferMPEG2
      
     /* Number of skipped macroblocks after this macroblock */
     uint16_t num_skipped_macroblocks;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAMacroblockParameterBufferMPEG2;
 
 /* 
@@ -1810,6 +1865,9 @@ typedef struct _VAPictureParameterBufferMPEG4
     /* for direct mode prediction */
     int16_t TRB;
     int16_t TRD;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAPictureParameterBufferMPEG4;
 
 /** MPEG-4 Inverse Quantization Matrix Buffer */
@@ -1823,6 +1881,9 @@ typedef struct _VAIQMatrixBufferMPEG4
     uint8_t intra_quant_mat[64];
     /** The matrix for non-intra blocks, in zig-zag scan order. */
     uint8_t non_intra_quant_mat[64];
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAIQMatrixBufferMPEG4;
 
 /** MPEG-4 Slice Parameter Buffer */
@@ -1834,6 +1895,9 @@ typedef struct _VASliceParameterBufferMPEG4
     uint32_t macroblock_offset;/* the offset to the first bit of MB from the first byte of slice data */
     uint32_t macroblock_number;
     int32_t quant_scale;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VASliceParameterBufferMPEG4;
 
 /**
@@ -2007,6 +2071,9 @@ typedef struct _VAPictureParameterBufferVC1
         } bits;
         uint32_t value;
     } transform_fields;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_MEDIUM];
 } VAPictureParameterBufferVC1;
 
 /** VC-1 Bitplane Buffer
@@ -2035,6 +2102,9 @@ typedef struct _VASliceParameterBufferVC1
     uint32_t slice_data_flag; /* see VA_SLICE_DATA_FLAG_XXX defintions */
     uint32_t macroblock_offset;/* the offset to the first bit of MB from the first byte of slice data */
     uint32_t slice_vertical_position;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VASliceParameterBufferVC1;
 
 /* VC-1 Slice Data Buffer */
@@ -2053,6 +2123,9 @@ typedef struct _VAPictureH264
     uint32_t flags;
     int32_t TopFieldOrderCnt;
     int32_t BottomFieldOrderCnt;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAPictureH264;
 /* flags in VAPictureH264 could be OR of the following */
 #define VA_PICTURE_H264_INVALID			0x00000001
@@ -2115,6 +2188,9 @@ typedef struct _VAPictureParameterBufferH264
         uint32_t value;
     } pic_fields;
     uint16_t frame_num;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_MEDIUM];
 } VAPictureParameterBufferH264;
 
 /** H.264 Inverse Quantization Matrix Buffer */
@@ -2124,6 +2200,9 @@ typedef struct _VAIQMatrixBufferH264
     uint8_t ScalingList4x4[6][16];
     /** \brief 8x8 scaling list, in raster scan order. */
     uint8_t ScalingList8x8[2][64];
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAIQMatrixBufferH264;
 
 /** H.264 Slice Parameter Buffer */
@@ -2182,6 +2261,9 @@ typedef struct _VASliceParameterBufferH264
     uint8_t chroma_weight_l1_flag;
     int16_t chroma_weight_l1[32][2];
     int16_t chroma_offset_l1[32][2];
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VASliceParameterBufferH264;
 
 /****************************
@@ -2208,6 +2290,9 @@ typedef struct _VAEncSliceParameterBuffer
         } bits;
         uint32_t value;
     } slice_flags;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncSliceParameterBuffer;
 
 
@@ -2222,6 +2307,9 @@ typedef struct _VAEncSequenceParameterBufferH263
     uint32_t frame_rate;
     uint32_t initial_qp;
     uint32_t min_qp;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncSequenceParameterBufferH263;
 
 typedef struct _VAEncPictureParameterBufferH263
@@ -2232,6 +2320,9 @@ typedef struct _VAEncPictureParameterBufferH263
     uint16_t picture_width;
     uint16_t picture_height;
     VAEncPictureType picture_type;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncPictureParameterBufferH263;
 
 /****************************
@@ -2251,6 +2342,9 @@ typedef struct _VAEncSequenceParameterBufferMPEG4
     uint32_t frame_rate;
     uint32_t initial_qp;
     uint32_t min_qp;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncSequenceParameterBufferMPEG4;
 
 typedef struct _VAEncPictureParameterBufferMPEG4
@@ -2263,6 +2357,9 @@ typedef struct _VAEncPictureParameterBufferMPEG4
     uint32_t modulo_time_base; /* number of 1s */
     uint32_t vop_time_increment;
     VAEncPictureType picture_type;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncPictureParameterBufferMPEG4;
 
 
@@ -2373,6 +2470,9 @@ typedef  struct _VACodedBufferSegment  {
      * or \c NULL if there is none.
      */
     void               *next;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VACodedBufferSegment;
      
 /**
@@ -2430,6 +2530,9 @@ typedef struct {
     uint32_t            mem_type;
     /** \brief Size of the underlying buffer. */
     size_t              mem_size;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VABufferInfo;
 
 /**
@@ -2608,6 +2711,9 @@ typedef struct _VASurfaceDecodeMBErrors
     uint32_t start_mb; /* start mb address with errors */
     uint32_t end_mb;  /* end mb address with errors */
     VADecodeErrorType decode_error_type;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VASurfaceDecodeMBErrors;
 
 /**
@@ -2700,6 +2806,9 @@ typedef struct _VAImageFormat
     uint32_t	green_mask;
     uint32_t	blue_mask;
     uint32_t	alpha_mask;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAImageFormat;
 
 typedef VAGenericID VAImageID;
@@ -2743,6 +2852,9 @@ typedef struct _VAImage
      * Only entry_bytes characters of the string are used.
      */
     int8_t component_order[4];
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAImage;
 
 /** Get maximum number of image formats supported by the implementation */
@@ -3122,6 +3234,9 @@ typedef struct _VADisplayAttribute
     int32_t value;	/* used by the set/get attribute functions */
 /* flags can be VA_DISPLAY_ATTRIB_GETTABLE or VA_DISPLAY_ATTRIB_SETTABLE or OR'd together */
     uint32_t flags;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VADisplayAttribute;
 
 /** Get maximum number of display attributs supported by the implementation */
@@ -3190,6 +3305,9 @@ typedef struct _VAPictureHEVC
     int32_t                 pic_order_cnt;
     /* described below */
     uint32_t                flags;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAPictureHEVC;
 
 /* flags in VAPictureHEVC could be OR of the following */

--- a/va/va_backend.h
+++ b/va/va_backend.h
@@ -435,6 +435,9 @@ struct VADriverVTable
             VADriverContextP    ctx,
             VABufferID          buf_id          /* in */
         );
+
+        /** \brief Reserved bytes for future use, must be zero */
+        unsigned long reserved[64];
 };
 
 struct VADriverContext
@@ -558,6 +561,9 @@ struct VADisplayContext
     void *error_callback_user_context;
     VAMessageCallback info_callback;
     void *info_callback_user_context;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    unsigned long reserved[32];
 };
 
 typedef VAStatus (*VADriverInit) (

--- a/va/va_backend_vpp.h
+++ b/va/va_backend_vpp.h
@@ -62,6 +62,9 @@ struct VADriverVTableVPP {
         unsigned int        num_filters,
         VAProcPipelineCaps *pipeline_caps
     );
+
+    /** \brief Reserved bytes for future use, must be zero */
+    unsigned long reserved[16];
 };
 
 #ifdef __cplusplus

--- a/va/va_dec_hevc.h
+++ b/va/va_dec_hevc.h
@@ -190,6 +190,8 @@ typedef struct  _VAPictureParameterBufferHEVC
      */
     uint32_t                st_rps_bits;
 
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_MEDIUM];
 } VAPictureParameterBufferHEVC;
 
 /**
@@ -321,6 +323,8 @@ typedef struct  _VASliceParameterBufferHEVC
     uint8_t                 five_minus_max_num_merge_cand;
     /**@}*/
 
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VASliceParameterBufferHEVC;
 
 
@@ -379,6 +383,9 @@ typedef struct _VAIQMatrixBufferHEVC
      * with sizeID = 3 and matrixID in the range of 0 to 1, inclusive.
      */
     uint8_t                 ScalingListDC32x32[2];
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAIQMatrixBufferHEVC;
 
 

--- a/va/va_dec_jpeg.h
+++ b/va/va_dec_jpeg.h
@@ -70,6 +70,9 @@ typedef struct _VAPictureParameterBufferJPEGBaseline {
     }                   components[255];
     /** \brief Number of components in frame (Nf). */
     uint8_t       num_components;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_MEDIUM];
 } VAPictureParameterBufferJPEGBaseline;
 
 /**
@@ -91,6 +94,9 @@ typedef struct _VAIQMatrixBufferJPEGBaseline {
     uint8_t       load_quantiser_table[4];
     /** \brief Quanziation tables indexed by table identifier (Tqi). */
     uint8_t       quantiser_table[4][64];
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAIQMatrixBufferJPEGBaseline;
 
 /**
@@ -131,6 +137,9 @@ typedef struct _VASliceParameterBufferJPEGBaseline {
     uint16_t      restart_interval;
     /** \brief Number of MCUs in a scan. */
     uint32_t        num_mcus;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VASliceParameterBufferJPEGBaseline;
 
 /**@}*/

--- a/va/va_dec_vp8.h
+++ b/va/va_dec_vp8.h
@@ -157,6 +157,8 @@ typedef struct  _VAPictureParameterBufferVP8
 
     VABoolCoderContextVPX bool_coder_ctx;
 
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAPictureParameterBufferVP8;
 
 /**
@@ -197,6 +199,9 @@ typedef struct  _VASliceParameterBufferVP8
      * exclude the uncompress data chunk since first_part_size 'excluding the uncompressed data chunk'
      */
     uint32_t partition_size[9];
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VASliceParameterBufferVP8;
 
 /**
@@ -216,6 +221,9 @@ typedef struct  _VASliceParameterBufferVP8
 typedef struct _VAProbabilityDataBufferVP8
 {
     uint8_t dct_coeff_probs[4][8][3][11];
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAProbabilityDataBufferVP8;
 
 /**
@@ -232,6 +240,9 @@ typedef struct _VAIQMatrixBufferVP8
      * all Q indexs should be clipped to be range [0, 127]
      */
     uint16_t quantization_index[4][6];
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAIQMatrixBufferVP8;
 
 /**@}*/

--- a/va/va_dec_vp9.h
+++ b/va/va_dec_vp9.h
@@ -191,6 +191,9 @@ typedef struct  _VADecPictureParameterBufferVP9
      */
     uint8_t                 bit_depth;
 
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_MEDIUM];
+
     /**@}*/
 
 } VADecPictureParameterBufferVP9;
@@ -263,6 +266,9 @@ typedef struct  _VASegmentParameterVP9
      */
     int16_t                 chroma_dc_quant_scale;
 
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
+
     /**@}*/
 
 } VASegmentParameterVP9;
@@ -307,6 +313,8 @@ typedef struct _VASliceParameterBufferVP9
      */
     VASegmentParameterVP9   seg_param[8];
 
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
     /**@}*/
 
 } VASliceParameterBufferVP9;

--- a/va/va_drmcommon.h
+++ b/va/va_drmcommon.h
@@ -66,6 +66,8 @@ struct drm_state {
     int         fd;
     /** \brief DRM authentication type. */
     int         auth_type;
+    /** \brief Reserved bytes for future use, must be zero */
+    int         va_reserved[8];
 };
 
 /** \brief Kernel DRM buffer memory type.  */

--- a/va/va_enc_h264.h
+++ b/va/va_enc_h264.h
@@ -246,6 +246,8 @@ typedef struct _VAEncSequenceParameterBufferH264 {
             uint32_t log2_max_mv_length_horizontal          : 5;
             /** \brief Range: 0 to 16, inclusive. */
             uint32_t log2_max_mv_length_vertical            : 5;
+            /** \brief Reserved for future use, must be zero */
+            uint32_t reserved                               : 19;
         } bits;
         uint32_t value;
     } vui_fields;
@@ -259,6 +261,9 @@ typedef struct _VAEncSequenceParameterBufferH264 {
     uint32_t    num_units_in_tick;
     /** \brief Same as the H.264 bitstream syntax element. */
     uint32_t    time_scale;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
     /**@}*/
 } VAEncSequenceParameterBufferH264;
 
@@ -371,6 +376,9 @@ typedef struct _VAEncPictureParameterBufferH264 {
         } bits;
         uint32_t value;
     } pic_fields;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncPictureParameterBufferH264;
 
 typedef struct _VAEncQPBufferH264 {
@@ -514,6 +522,9 @@ typedef struct _VAEncSliceParameterBufferH264 {
     int8_t     slice_alpha_c0_offset_div2;
     /** \brief Same as the H.264 bitstream syntax element. */
     int8_t     slice_beta_offset_div2;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
     /**@}*/
 } VAEncSliceParameterBufferH264;
 
@@ -595,6 +606,9 @@ typedef struct _VAEncMacroblockParameterBufferH264 {
         } inter_fields;
         /**@}*/
     } info;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncMacroblockParameterBufferH264;
 
 /**@}*/

--- a/va/va_enc_hevc.h
+++ b/va/va_enc_hevc.h
@@ -316,6 +316,9 @@ typedef struct _VAEncSequenceParameterBufferHEVC {
     uint8_t     max_bytes_per_pic_denom;
     /** \brief Same as the HEVC bitstream syntax element. */
     uint8_t     max_bits_per_min_cu_denom;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_MEDIUM];
     /**@}*/
 } VAEncSequenceParameterBufferHEVC;
 
@@ -517,6 +520,9 @@ typedef struct _VAEncPictureParameterBufferHEVC {
         } bits;
         uint32_t        value;
     } pic_fields;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_HIGH];
 } VAEncPictureParameterBufferHEVC;
 
 /**
@@ -640,6 +646,9 @@ typedef struct _VAEncSliceParameterBufferHEVC {
         } bits;
         uint32_t        value;
     } slice_fields;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_MEDIUM];
     /**@}*/
 } VAEncSliceParameterBufferHEVC;
 
@@ -695,6 +704,9 @@ typedef struct _VAQMatrixBufferHEVC
      * with sizeID = 3 and matrixID in the range of 0 to 1, inclusive.
      */
     uint8_t             scaling_list_dc_32x32[2];
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAQMatrixBufferHEVC;
 
 /**@}*/

--- a/va/va_enc_jpeg.h
+++ b/va/va_enc_jpeg.h
@@ -107,6 +107,8 @@ typedef struct  _VAEncPictureParameterBufferJPEG
     /** \brief number from 1 to 100 that specifies quality of image. */
     uint8_t    quality;
 
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncPictureParameterBufferJPEG;
 
 
@@ -129,6 +131,9 @@ typedef struct _VAEncSliceParameterBufferJPEG {
         /** \brief AC entropy coding table selector (Taj). */
         uint8_t   ac_table_selector;
     } components[4];
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncSliceParameterBufferJPEG;
 
 /**
@@ -145,6 +150,9 @@ typedef struct _VAQMatrixBufferJPEG
     uint8_t lum_quantiser_matrix[64];
     /** \brief chroma quantization table. */
     uint8_t chroma_quantiser_matrix[64];
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAQMatrixBufferJPEG;
 
 /**@}*/

--- a/va/va_enc_mpeg2.h
+++ b/va/va_enc_mpeg2.h
@@ -165,6 +165,9 @@ typedef struct _VAEncSequenceParameterBufferMPEG2 {
         } bits;
         uint32_t value;
     } gop_header;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncSequenceParameterBufferMPEG2;
 
 /**
@@ -261,6 +264,9 @@ typedef struct _VAEncPictureParameterBufferMPEG2 {
         } bits;
         uint32_t value;
     } composite_display;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncPictureParameterBufferMPEG2;
 
 /**
@@ -276,6 +282,9 @@ typedef struct _VAEncSliceParameterBufferMPEG2 {
     int32_t quantiser_scale_code;
     /** \brief Flag to indicate intra slice */
     int32_t is_intra_slice;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncSliceParameterBufferMPEG2;
 
 /**@}*/

--- a/va/va_enc_vp8.h
+++ b/va/va_enc_vp8.h
@@ -93,6 +93,8 @@ typedef struct  _VAEncSequenceParameterBufferVP8
      */
     VASurfaceID reference_frames[4];
 
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncSequenceParameterBufferVP8;
 
 
@@ -128,6 +130,7 @@ typedef struct  _VAEncPictureParameterBufferVP8
             uint32_t no_ref_gf                      : 1;
             /* don't reference the alternate reference frame */
             uint32_t no_ref_arf                     : 1;
+            /** \brief Reserved for future use, must be zero */
             uint32_t reserved                       : 28;
         } bits;
         uint32_t value;
@@ -278,7 +281,9 @@ typedef struct  _VAEncPictureParameterBufferVP8
      * otherwise they are ignored. 
      */
     uint8_t clamp_qindex_low;
-	
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncPictureParameterBufferVP8;
 
 
@@ -302,6 +307,9 @@ typedef struct _VAEncMBMapBufferVP8
      * per MB Segmentation ID Buffer
      */
     uint8_t *mb_segment_id;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncMBMapBufferVP8;
 
 
@@ -317,6 +325,9 @@ typedef struct _VAQMatrixBufferVP8
 {
     uint16_t quantization_index[4];
     int16_t quantization_index_delta[5];
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAQMatrixBufferVP8;
 
 

--- a/va/va_enc_vp9.h
+++ b/va/va_enc_vp9.h
@@ -83,6 +83,8 @@ typedef struct  _VACodedBufferVP9Status
     /* suggested next frame height */
     uint16_t	next_frame_height;
 
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VACodedBufferVP9Status;
 
 /**
@@ -136,6 +138,8 @@ typedef struct  _VAEncSequenceParameterBufferVP9
     /* Period between key frames */
     uint32_t    intra_period;
 
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncSequenceParameterBufferVP9;
 
 
@@ -506,6 +510,8 @@ typedef struct  _VAEncPictureParameterBufferVP9
      */
     uint32_t    skip_frames_size;
 
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t    va_reserved[VA_PADDING_MEDIUM];
 } VAEncPictureParameterBufferVP9;
 
 
@@ -557,6 +563,8 @@ typedef struct _VAEncSegParamVP9
      */
     int16_t     segment_qindex_delta;
 
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncSegParamVP9;
 
 /**
@@ -575,6 +583,8 @@ typedef struct _VAEncMiscParameterTypeVP9PerSegmantParam
      */
     VAEncSegParamVP9    seg_data[8];
 
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAEncMiscParameterTypeVP9PerSegmantParam;
 
 

--- a/va/va_fei_h264.h
+++ b/va/va_fei_h264.h
@@ -134,7 +134,7 @@ typedef struct _VAEncMiscParameterFEIFrameControlH264
     uint32_t      num_passes;
     /** \brief delta QP list for every pass */
     uint8_t       *delta_qp;
-    uint32_t      reserved3[2];
+    uint32_t      reserved3[VA_PADDING_LOW];
 } VAEncMiscParameterFEIFrameControlH264;
 
 /** \brief FEI MB level control data structure */

--- a/va/va_vpp.h
+++ b/va/va_vpp.h
@@ -354,6 +354,9 @@ typedef struct _VAProcPipelineCaps {
     VAProcColorStandardType *output_color_standards;
     /** \brief Number of elements in \ref output_color_standards array. */
     uint32_t        num_output_color_standards;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LARGE];
 } VAProcPipelineCaps;
 
 /** \brief Specification of values supported by the filter. */
@@ -366,6 +369,9 @@ typedef struct _VAProcFilterValueRange {
     float               default_value;
     /** \brief Step value that alters the filter behaviour in a sensible way. */
     float               step;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAProcFilterValueRange;
 
 /**
@@ -501,6 +507,9 @@ typedef struct _VAProcPipelineParameterBuffer {
     VASurfaceID        *backward_references;
     /** \brief Number of backward reference frames that were supplied. */
     uint32_t        num_backward_references;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LARGE];
 } VAProcPipelineParameterBuffer;
 
 /**
@@ -526,6 +535,9 @@ typedef struct _VAProcFilterParameterBuffer {
     VAProcFilterType    type;
     /** \brief Value. */
     float               value;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAProcFilterParameterBuffer;
 
 /** @name De-interlacing flags */
@@ -555,6 +567,9 @@ typedef struct _VAProcFilterParameterBufferDeinterlacing {
     VAProcDeinterlacingType     algorithm;
     /** \brief Deinterlacing flags. */
     uint32_t     		flags;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAProcFilterParameterBufferDeinterlacing;
 
 /**
@@ -616,6 +631,9 @@ typedef struct _VAProcFilterParameterBufferColorBalance {
      *   disabled and other attribute of the same type is used instead.
      */
     float                       value;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAProcFilterParameterBufferColorBalance;
 
 /**
@@ -627,12 +645,18 @@ typedef struct _VAProcFilterParameterBufferColorBalance {
 typedef struct _VAProcFilterCap {
     /** \brief Range of supported values for the filter. */
     VAProcFilterValueRange      range;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAProcFilterCap;
 
 /** \brief Capabilities specification for the deinterlacing filter. */
 typedef struct _VAProcFilterCapDeinterlacing {
     /** \brief Deinterlacing algorithm. */
     VAProcDeinterlacingType     type;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAProcFilterCapDeinterlacing;
 
 /** \brief Capabilities specification for the color balance filter. */
@@ -641,6 +665,9 @@ typedef struct _VAProcFilterCapColorBalance {
     VAProcColorBalanceType      type;
     /** \brief Range of supported values for the specified operation. */
     VAProcFilterValueRange      range;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    uint32_t                va_reserved[VA_PADDING_LOW];
 } VAProcFilterCapColorBalance;
 
 /**

--- a/va/wayland/va_backend_wayland.h
+++ b/va/wayland/va_backend_wayland.h
@@ -63,6 +63,9 @@ struct VADriverVTableWayland {
 
     /** \brief Indicate whether buffer sharing with prime fd is supported. */
     unsigned int has_prime_sharing;
+
+    /** \brief Reserved bytes for future use, must be zero */
+    unsigned long reserved[8];
 };
 
 #endif /* VA_BACKEND_WAYLAND_H */

--- a/va/x11/va_dricommon.h
+++ b/va/x11/va_dricommon.h
@@ -55,6 +55,8 @@ union dri_buffer
         unsigned int pitch;
         unsigned int cpp;
         unsigned int flags;
+        /** \brief Reserved bytes for future use, must be zero */
+        unsigned int va_reserved[8];
     } dri2;
 };
 
@@ -82,6 +84,8 @@ struct dri_state
     union dri_buffer *(*getRenderingBuffer)(VADriverContextP ctx, struct dri_drawable *dri_drawable);
     void (*close)(VADriverContextP ctx);
 #endif
+    /** \brief Reserved bytes for future use, must be zero */
+    unsigned long  va_reserved[16];
 };
 
 Bool va_isDRI2Connected(VADriverContextP ctx, char **driver_name);


### PR DESCRIPTION
The reserved bytes must be set to 0, then we can add new fields to those
structures in future without worrying about the API compatibility too
much.
