### PR TITLE
va: Add functions for converting common enums to strings

### DIFF
--- a/va/Makefile.am
+++ b/va/Makefile.am
@@ -33,6 +33,7 @@ libva_source_c = \
 	va.c			\
 	va_compat.c		\
 	va_fool.c		\
+	va_str.c		\
 	va_trace.c		\
 	$(NULL)
 
@@ -55,6 +56,7 @@ libva_source_h = \
 	va_fei_h264.h		\
 	va_enc_mpeg2.h		\
 	va_enc_vp9.h            \
+	va_str.h		\
 	va_tpi.h		\
 	va_version.h		\
 	va_vpp.h		\

--- a/va/va_str.c
+++ b/va/va_str.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2017 Intel Corporation. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sub license, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the
+ * next paragraph) shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
+ * IN NO EVENT SHALL PRECISION INSIGHT AND/OR ITS SUPPLIERS BE LIABLE FOR
+ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "va_str.h"
+
+#define TOSTR(enumCase) case enumCase: return #enumCase
+
+const char *vaProfileStr(VAProfile profile)
+{
+    switch (profile) {
+    TOSTR(VAProfileNone);
+    TOSTR(VAProfileMPEG2Simple);
+    TOSTR(VAProfileMPEG2Main);
+    TOSTR(VAProfileMPEG4Simple);
+    TOSTR(VAProfileMPEG4AdvancedSimple);
+    TOSTR(VAProfileMPEG4Main);
+    TOSTR(VAProfileH264Main);
+    TOSTR(VAProfileH264High);
+    TOSTR(VAProfileVC1Simple);
+    TOSTR(VAProfileVC1Main);
+    TOSTR(VAProfileVC1Advanced);
+    TOSTR(VAProfileH263Baseline);
+    TOSTR(VAProfileH264ConstrainedBaseline);
+    TOSTR(VAProfileJPEGBaseline);
+    TOSTR(VAProfileVP8Version0_3);
+    TOSTR(VAProfileH264MultiviewHigh);
+    TOSTR(VAProfileH264StereoHigh);
+    TOSTR(VAProfileHEVCMain);
+    TOSTR(VAProfileHEVCMain10);
+    TOSTR(VAProfileVP9Profile0);
+    TOSTR(VAProfileVP9Profile1);
+    TOSTR(VAProfileVP9Profile2);
+    TOSTR(VAProfileVP9Profile3);
+    }
+    return "<unknown profile>";
+}
+
+
+const char *vaEntrypointStr(VAEntrypoint entrypoint)
+{
+    switch (entrypoint) {
+    TOSTR(VAEntrypointVLD);
+    TOSTR(VAEntrypointIZZ);
+    TOSTR(VAEntrypointIDCT);
+    TOSTR(VAEntrypointMoComp);
+    TOSTR(VAEntrypointDeblocking);
+    TOSTR(VAEntrypointEncSlice);
+    TOSTR(VAEntrypointEncPicture);
+    TOSTR(VAEntrypointEncSliceLP);
+    TOSTR(VAEntrypointVideoProc);
+    TOSTR(VAEntrypointFEI);
+    }
+    return "<unknown entrypoint>";
+}
+
+const char *vaConfigAttribTypeStr(VAConfigAttribType configAttribType)
+{
+    switch (configAttribType) {
+    TOSTR(VAConfigAttribRTFormat);
+    TOSTR(VAConfigAttribSpatialResidual);
+    TOSTR(VAConfigAttribSpatialClipping);
+    TOSTR(VAConfigAttribIntraResidual);
+    TOSTR(VAConfigAttribEncryption);
+    TOSTR(VAConfigAttribRateControl);
+    TOSTR(VAConfigAttribDecSliceMode);
+    TOSTR(VAConfigAttribEncPackedHeaders);
+    TOSTR(VAConfigAttribEncInterlaced);
+    TOSTR(VAConfigAttribEncMaxRefFrames);
+    TOSTR(VAConfigAttribEncMaxSlices);
+    TOSTR(VAConfigAttribEncSliceStructure);
+    TOSTR(VAConfigAttribEncMacroblockInfo);
+    TOSTR(VAConfigAttribEncJPEG);
+    TOSTR(VAConfigAttribEncQualityRange);
+    TOSTR(VAConfigAttribEncSkipFrame);
+    TOSTR(VAConfigAttribEncROI);
+    TOSTR(VAConfigAttribEncRateControlExt);
+    }
+    return "<unknown config attribute type>";
+}
+
+const char *vaBufferTypeStr(VABufferType bufferType)
+{
+    switch (bufferType) {
+    TOSTR(VAPictureParameterBufferType);
+    TOSTR(VAIQMatrixBufferType);
+    TOSTR(VABitPlaneBufferType);
+    TOSTR(VASliceGroupMapBufferType);
+    TOSTR(VASliceParameterBufferType);
+    TOSTR(VASliceDataBufferType);
+    TOSTR(VAMacroblockParameterBufferType);
+    TOSTR(VAResidualDataBufferType);
+    TOSTR(VADeblockingParameterBufferType);
+    TOSTR(VAImageBufferType);
+    TOSTR(VAProtectedSliceDataBufferType);
+    TOSTR(VAQMatrixBufferType);
+    TOSTR(VAHuffmanTableBufferType);
+    TOSTR(VAProbabilityBufferType);
+    TOSTR(VAEncCodedBufferType);
+    TOSTR(VAEncSequenceParameterBufferType);
+    TOSTR(VAEncPictureParameterBufferType);
+    TOSTR(VAEncSliceParameterBufferType);
+    TOSTR(VAEncPackedHeaderParameterBufferType);
+    TOSTR(VAEncPackedHeaderDataBufferType);
+    TOSTR(VAEncMiscParameterBufferType);
+    TOSTR(VAEncMacroblockParameterBufferType);
+    TOSTR(VAEncMacroblockMapBufferType);
+    TOSTR(VAProcPipelineParameterBufferType);
+    TOSTR(VAProcFilterParameterBufferType);
+    }
+    return "<unknown buffer type>";
+}
+
+#undef TOSTR

--- a/va/va_str.h
+++ b/va/va_str.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2017 Intel Corporation. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sub license, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the
+ * next paragraph) shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
+ * IN NO EVENT SHALL INTEL AND/OR ITS SUPPLIERS BE LIABLE FOR
+ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
+#ifndef _VA_STR_H_
+#define _VA_STR_H_
+
+#include <va/va.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+const char *vaProfileStr(VAProfile profile);
+
+const char *vaEntrypointStr(VAEntrypoint entrypoint);
+
+const char *vaConfigAttribTypeStr(VAConfigAttribType configAttribType);
+
+const char *vaBufferTypeStr(VABufferType bufferType);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _VA_STR_H_ */

--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -37,6 +37,7 @@
 #include "va_dec_vp8.h"
 #include "va_dec_vp9.h"
 #include "va_dec_hevc.h"
+#include "va_str.h"
 #include "va_vpp.h"
 #include <assert.h>
 #include <stdarg.h>
@@ -1435,37 +1436,6 @@ void va_TraceDestroyContext (
     UNLOCK_CONTEXT(pva_trace);
 }
 
-static char * buffer_type_to_string(int type)
-{
-    switch (type) {
-    case VAPictureParameterBufferType: return "VAPictureParameterBufferType";
-    case VAIQMatrixBufferType: return "VAIQMatrixBufferType";
-    case VABitPlaneBufferType: return "VABitPlaneBufferType";
-    case VASliceGroupMapBufferType: return "VASliceGroupMapBufferType";
-    case VASliceParameterBufferType: return "VASliceParameterBufferType";
-    case VASliceDataBufferType: return "VASliceDataBufferType";
-    case VAProtectedSliceDataBufferType: return "VAProtectedSliceDataBufferType";
-    case VAMacroblockParameterBufferType: return "VAMacroblockParameterBufferType";
-    case VAResidualDataBufferType: return "VAResidualDataBufferType";
-    case VADeblockingParameterBufferType: return "VADeblockingParameterBufferType";
-    case VAImageBufferType: return "VAImageBufferType";
-    case VAQMatrixBufferType: return "VAQMatrixBufferType";
-    case VAHuffmanTableBufferType: return "VAHuffmanTableBufferType";
-/* Following are encode buffer types */
-    case VAEncCodedBufferType: return "VAEncCodedBufferType";
-    case VAEncSequenceParameterBufferType: return "VAEncSequenceParameterBufferType";
-    case VAEncPictureParameterBufferType: return "VAEncPictureParameterBufferType";
-    case VAEncSliceParameterBufferType: return "VAEncSliceParameterBufferType";
-    case VAEncPackedHeaderParameterBufferType: return "VAEncPackedHeaderParameterBufferType";
-    case VAEncPackedHeaderDataBufferType: return "VAEncPackedHeaderDataBufferType";
-    case VAEncMiscParameterBufferType: return "VAEncMiscParameterBufferType";
-    case VAEncMacroblockParameterBufferType: return "VAEncMacroblockParameterBufferType";
-    case VAProcPipelineParameterBufferType: return "VAProcPipelineParameterBufferType";
-    case VAProcFilterParameterBufferType: return "VAProcFilterParameterBufferType";
-    default: return "UnknowBuffer";
-    }
-}
-
 void va_TraceCreateBuffer (
     VADisplay dpy,
     VAContextID context,	/* in */
@@ -1488,7 +1458,7 @@ void va_TraceCreateBuffer (
         return;
 
     TRACE_FUNCNAME(idx);
-    va_TraceMsg(trace_ctx, "\tbuf_type=%s\n", buffer_type_to_string(type));
+    va_TraceMsg(trace_ctx, "\tbuf_type=%s\n", vaBufferTypeStr(type));
     if (buf_id)
         va_TraceMsg(trace_ctx, "\tbuf_id=0x%x\n", *buf_id);
     va_TraceMsg(trace_ctx, "\tsize=%u\n", size);
@@ -1520,7 +1490,7 @@ void va_TraceDestroyBuffer (
         return;
 
     TRACE_FUNCNAME(idx);
-    va_TraceMsg(trace_ctx, "\tbuf_type=%s\n", buffer_type_to_string(type));
+    va_TraceMsg(trace_ctx, "\tbuf_type=%s\n", vaBufferTypeStr(type));
     va_TraceMsg(trace_ctx, "\tbuf_id=0x%x\n", buf_id);
     va_TraceMsg(trace_ctx, "\tsize=%u\n", size);
     va_TraceMsg(trace_ctx, "\tnum_elements=%u\n", num_elements);
@@ -1606,7 +1576,7 @@ void va_TraceMapBuffer (
 
     TRACE_FUNCNAME(idx);
     va_TraceMsg(trace_ctx, "\tbuf_id=0x%x\n", buf_id);
-    va_TraceMsg(trace_ctx, "\tbuf_type=%s\n", buffer_type_to_string(type));
+    va_TraceMsg(trace_ctx, "\tbuf_type=%s\n", vaBufferTypeStr(type));
     if ((pbuf == NULL) || (*pbuf == NULL))
         return;
 
@@ -1653,7 +1623,7 @@ static void va_TraceVABuffers(
 
     DPY2TRACECTX(dpy, context, VA_INVALID_ID);
     
-    va_TracePrint(trace_ctx, "--%s\n", buffer_type_to_string(type));
+    va_TracePrint(trace_ctx, "--%s\n", vaBufferTypeStr(type));
 
     if(trace_ctx->plog_file)
         fp = trace_ctx->plog_file->fp_log;
@@ -4767,7 +4737,7 @@ void va_TraceRenderPicture(
 
         va_TraceMsg(trace_ctx, "\t---------------------------\n");
         va_TraceMsg(trace_ctx, "\tbuffers[%d] = 0x%08x\n", i, buffers[i]);
-        va_TraceMsg(trace_ctx, "\t  type = %s\n", buffer_type_to_string(type));
+        va_TraceMsg(trace_ctx, "\t  type = %s\n", vaBufferTypeStr(type));
         va_TraceMsg(trace_ctx, "\t  size = %d\n", size);
         va_TraceMsg(trace_ctx, "\t  num_elements = %d\n", num_elements);
 


### PR DESCRIPTION
These will be used by libva-utils' vainfo and (eventually) by libyami.