### PR TITLE
va_internal:  list va_internal on noinst_HEADERS

### DIFF
--- a/va/Makefile.am
+++ b/va/Makefile.am
@@ -63,6 +63,7 @@ libva_source_h = \
 libva_source_h_priv = \
 	sysdeps.h		\
 	va_fool.h		\
+	va_internal.h		\
 	va_trace.h		\
 	$(NULL)
 


### PR DESCRIPTION
va_internal.h is not to be installed

Signed-off-by: Daniel Charles <daniel.charles@intel.com>