### PR TITLE
Fix segmentation fault in VA tracer

### DIFF
--- a/va/va_fool.c
+++ b/va/va_fool.c
@@ -262,7 +262,7 @@ VAStatus va_FoolBufferInfo(
     return 1; /* fool is valid */
 }
 
-static int va_FoolFillCodedBufEnc(struct fool_context *fool_ctx)
+static int va_FoolFillCodedBufEnc(VADisplay dpy, struct fool_context *fool_ctx)
 {
     char file_name[1024];
     struct stat file_stat = {0};
@@ -287,10 +287,10 @@ static int va_FoolFillCodedBufEnc(struct fool_context *fool_ctx)
         fool_ctx->segbuf_enc = realloc(fool_ctx->segbuf_enc, file_stat.st_size);
         ret = read(fd, fool_ctx->segbuf_enc, file_stat.st_size);
         if (ret < file_stat.st_size)
-            va_errorMessage("Reading file %s failed.\n", file_name);
+            va_errorMessage(dpy, "Reading file %s failed.\n", file_name);
         close(fd);
     } else
-        va_errorMessage("Open file %s failed:%s\n", file_name, strerror(errno));
+        va_errorMessage(dpy, "Open file %s failed:%s\n", file_name, strerror(errno));
 
     codedbuf = (VACodedBufferSegment *)fool_ctx->fool_buf[VAEncCodedBufferType];
     codedbuf->size = file_stat.st_size;
@@ -303,7 +303,7 @@ static int va_FoolFillCodedBufEnc(struct fool_context *fool_ctx)
     return 0;
 }
 
-static int va_FoolFillCodedBufJPG(struct fool_context *fool_ctx)
+static int va_FoolFillCodedBufJPG(VADisplay dpy, struct fool_context *fool_ctx)
 {
     struct stat file_stat = {0};
     VACodedBufferSegment *codedbuf;
@@ -315,10 +315,10 @@ static int va_FoolFillCodedBufJPG(struct fool_context *fool_ctx)
         fool_ctx->segbuf_jpg = realloc(fool_ctx->segbuf_jpg, file_stat.st_size);
         ret = read(fd, fool_ctx->segbuf_jpg, file_stat.st_size);
         if (ret < file_stat.st_size)
-            va_errorMessage("Reading file %s failed.\n", fool_ctx->fn_jpg);
+            va_errorMessage(dpy, "Reading file %s failed.\n", fool_ctx->fn_jpg);
         close(fd);
     } else
-        va_errorMessage("Open file %s failed:%s\n", fool_ctx->fn_jpg, strerror(errno));
+        va_errorMessage(dpy, "Open file %s failed:%s\n", fool_ctx->fn_jpg, strerror(errno));
 
     codedbuf = (VACodedBufferSegment *)fool_ctx->fool_buf[VAEncCodedBufferType];
     codedbuf->size = file_stat.st_size;
@@ -332,12 +332,12 @@ static int va_FoolFillCodedBufJPG(struct fool_context *fool_ctx)
 }
 
 
-static int va_FoolFillCodedBuf(struct fool_context *fool_ctx)
+static int va_FoolFillCodedBuf(VADisplay dpy, struct fool_context *fool_ctx)
 {
     if (fool_ctx->entrypoint == VAEntrypointEncSlice)
-        va_FoolFillCodedBufEnc(fool_ctx);
+        va_FoolFillCodedBufEnc(dpy, fool_ctx);
     else if (fool_ctx->entrypoint == VAEntrypointEncPicture)
-        va_FoolFillCodedBufJPG(fool_ctx);
+        va_FoolFillCodedBufJPG(dpy, fool_ctx);
         
     return 0;
 }
@@ -361,7 +361,7 @@ VAStatus va_FoolMapBuffer(
 
     /* it is coded buffer, fill coded segment from file */
     if (*pbuf && (buftype == VAEncCodedBufferType))
-        va_FoolFillCodedBuf(fool_ctx);
+        va_FoolFillCodedBuf(dpy, fool_ctx);
     
     return 1; /* fool is valid */
 }

--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -561,13 +561,13 @@ static int open_tracing_specil_file(
     if(type == 0) {
         ptra_ctx->trace_codedbuf_fn = fn_env;
         ptra_ctx->trace_fp_codedbuf = fp;
-        va_infoMessage("LIBVA_TRACE_CODEDBUF is on, save codedbuf into %s\n",
+        va_infoMessage(pva_trace->dpy, "LIBVA_TRACE_CODEDBUF is on, save codedbuf into %s\n",
             fn_env);
     }
     else {
         ptra_ctx->trace_surface_fn = fn_env;
         ptra_ctx->trace_fp_surface = fp;
-        va_infoMessage("LIBVA_TRACE_SURFACE is on, save surface into %s\n",
+        va_infoMessage(pva_trace->dpy, "LIBVA_TRACE_SURFACE is on, save surface into %s\n",
             fn_env);
     }
 
@@ -615,7 +615,7 @@ static int open_tracing_log_file(
         if(!pfp)
             goto FAIL;
 
-        va_infoMessage("%s %s for the thread 0x%08x\n",
+        va_infoMessage(pva_trace->dpy, "%s %s for the thread 0x%08x\n",
             new_fn_flag ? "Open new log file" : "Append to log file",
             plog_file->fn_log, thd_id);
 
@@ -741,6 +741,8 @@ void va_TraceInit(VADisplay dpy)
         return;
     }
 
+    pva_trace->dpy = dpy;
+
     if (va_parseConfig("LIBVA_TRACE", &env_value[0]) == 0) {
         pva_trace->fn_log_env = strdup(env_value);
         trace_ctx->plog_file = start_tracing2log_file(pva_trace);
@@ -748,11 +750,11 @@ void va_TraceInit(VADisplay dpy)
             trace_ctx->plog_file_list[0] = trace_ctx->plog_file;
             va_trace_flag = VA_TRACE_FLAG_LOG;
 
-            va_infoMessage("LIBVA_TRACE is on, save log into %s\n",
+            va_infoMessage(dpy, "LIBVA_TRACE is on, save log into %s\n",
                 trace_ctx->plog_file->fn_log);
         }
         else
-            va_errorMessage("Open file %s failed (%s)\n", env_value, strerror(errno));
+            va_errorMessage(dpy, "Open file %s failed (%s)\n", env_value, strerror(errno));
     }
 
     /* may re-get the global settings for multiple context */
@@ -810,7 +812,6 @@ void va_TraceInit(VADisplay dpy)
     pva_trace->ptra_ctx[MAX_TRACE_CTX_NUM] = trace_ctx;
 
     ((VADisplayContextP)dpy)->vatrace = (void *)pva_trace;
-    pva_trace->dpy = dpy;
 
     if(!va_trace_flag)
         va_TraceEnd(dpy);
@@ -882,6 +883,7 @@ void va_TraceEnd(VADisplay dpy)
     }
     free(pva_trace->ptra_ctx[MAX_TRACE_CTX_NUM]);
 
+    pva_trace->dpy = NULL;
     free(pva_trace);
     ((VADisplayContextP)dpy)->vatrace = NULL;
 }


### PR DESCRIPTION
The first parameter of va_{error,info}Message is VADisplay

This fixes https://github.com/01org/libva/issues/123

Signed-off-by: Xiang, Haihao <haihao.xiang@intel.com>