### PR TITLE
Add a more flexible interface for import/export of DRM objects

### DIFF
--- a/va/va.c
+++ b/va/va.c
@@ -1457,6 +1457,23 @@ vaReleaseBufferHandle(VADisplay dpy, VABufferID buf_id)
     return ctx->vtable->vaReleaseBufferHandle(ctx, buf_id);
 }
 
+VAStatus
+vaExportSurfaceHandle(VADisplay dpy, VASurfaceID surface_id,
+                      uint32_t mem_type, uint32_t flags,
+                      void *descriptor)
+{
+    VADriverContextP ctx;
+
+    CHECK_DISPLAY(dpy);
+    ctx = CTX(dpy);
+
+    if (!ctx->vtable->vaExportSurfaceHandle)
+        return VA_STATUS_ERROR_UNIMPLEMENTED;
+    return ctx->vtable->vaExportSurfaceHandle(ctx, surface_id,
+                                              mem_type, flags,
+                                              descriptor);
+}
+
 VAStatus vaBeginPicture (
     VADisplay dpy,
     VAContextID context,

--- a/va/va.h
+++ b/va/va.h
@@ -3303,6 +3303,68 @@ vaAcquireBufferHandle(VADisplay dpy, VABufferID buf_id, VABufferInfo *buf_info);
 VAStatus
 vaReleaseBufferHandle(VADisplay dpy, VABufferID buf_id);
 
+/** @name vaExportSurfaceHandle() flags
+ *
+ * @{
+ */
+/** Export surface to be read by external API. */
+#define VA_EXPORT_SURFACE_READ_ONLY        0x0001
+/** Export surface to be written by external API. */
+#define VA_EXPORT_SURFACE_WRITE_ONLY       0x0002
+/** Export surface to be both read and written by external API. */
+#define VA_EXPORT_SURFACE_READ_WRITE       0x0003
+/** Export surface with separate layers.
+ *
+ * For example, NV12 surfaces should be exported as two separate
+ * planes for luma and chroma.
+ */
+#define VA_EXPORT_SURFACE_SEPARATE_LAYERS  0x0004
+/** Export surface with composed layers.
+ *
+ * For example, NV12 surfaces should be exported as a single NV12
+ * composed object.
+ */
+#define VA_EXPORT_SURFACE_COMPOSED_LAYERS  0x0008
+
+/** @} */
+
+/**
+ * \brief Export a handle to a surface for use with an external API
+ *
+ * The exported handles are owned by the caller, and the caller is
+ * responsible for freeing them when no longer needed (e.g. by closing
+ * DRM PRIME file descriptors).
+ *
+ * This does not perform any synchronisation.  If the contents of the
+ * surface will be read, vaSyncSurface() must be called before doing so.
+ * If the contents of the surface are written, then all operations must
+ * be completed externally before using the surface again by via VA-API
+ * functions.
+ *
+ * @param[in] dpy          VA display.
+ * @param[in] surface_id   Surface to export.
+ * @param[in] mem_type     Memory type to export to.
+ * @param[in] flags        Combination of flags to apply
+ *   (VA_EXPORT_SURFACE_*).
+ * @param[out] descriptor  Pointer to the descriptor structure to fill
+ *   with the handle details.  The type of this structure depends on
+ *   the value of mem_type.
+ *
+ * @return Status code:
+ * - VA_STATUS_SUCCESS:    Success.
+ * - VA_STATUS_ERROR_INVALID_DISPLAY:  The display is not valid.
+ * - VA_STATUS_ERROR_UNIMPLEMENTED:  The driver does not implement
+ *     this interface.
+ * - VA_STATUS_ERROR_INVALID_SURFACE:  The surface is not valid, or
+ *     the surface is not exportable in the specified way.
+ * - VA_STATUS_ERROR_UNSUPPORTED_MEMORY_TYPE:  The driver does not
+ *     support exporting surfaces to the specified memory type.
+ */
+VAStatus vaExportSurfaceHandle(VADisplay dpy,
+                               VASurfaceID surface_id,
+                               uint32_t mem_type, uint32_t flags,
+                               void *descriptor);
+
 /**
  * Render (Video Decode/Encode/Processing) Pictures
  *

--- a/va/va_backend.h
+++ b/va/va_backend.h
@@ -476,8 +476,18 @@ struct VADriverVTable
             VAProcessingRateParameter *proc_buf,/* in */
             unsigned int *processing_rate	/* out */
         );
+
+        VAStatus
+        (*vaExportSurfaceHandle)(
+            VADriverContextP    ctx,
+            VASurfaceID         surface_id,     /* in */
+            uint32_t            mem_type,       /* in */
+            uint32_t            flags,          /* in */
+            void               *descriptor      /* out */
+        );
+
         /** \brief Reserved bytes for future use, must be zero */
-        unsigned long reserved[58];
+        unsigned long reserved[57];
 };
 
 struct VADriverContext

--- a/va/va_drmcommon.h
+++ b/va/va_drmcommon.h
@@ -27,6 +27,9 @@
 #ifndef VA_DRM_COMMON_H
 #define VA_DRM_COMMON_H
 
+#include <stdint.h>
+
+
 /** \brief DRM authentication type. */
 enum {
     /** \brief Disconnected. */
@@ -72,7 +75,69 @@ struct drm_state {
 
 /** \brief Kernel DRM buffer memory type.  */
 #define VA_SURFACE_ATTRIB_MEM_TYPE_KERNEL_DRM		0x10000000
-/** \brief DRM PRIME memory type. */
+/** \brief DRM PRIME memory type (old version)
+ *
+ * This supports only single objects with restricted memory layout.
+ * Used with VASurfaceAttribExternalBuffers.
+ */
 #define VA_SURFACE_ATTRIB_MEM_TYPE_DRM_PRIME		0x20000000
+/** \brief DRM PRIME memory type
+ *
+ * Used with VADRMPRIMESurfaceDescriptor.
+ */
+#define VA_SURFACE_ATTRIB_MEM_TYPE_DRM_PRIME_2		0x40000000
+
+/**
+ * \brief External buffer descriptor for a DRM PRIME surface.
+ *
+ * This can currently only be used for export.
+ *
+ * For export, call vaAcquireSurfaceHandle() with mem_type set to
+ * VA_SURFACE_ATTRIB_MEM_TYPE_DRM_PRIME_2 and pass a pointer to an
+ * instance of this structure to fill.
+ * If VA_EXPORT_SURFACE_SEPARATE_LAYERS is specified on export, each
+ * layer will contain exactly one plane.  For example, an NV12
+ * surface will be exported as two layers, one of DRM_FORMAT_R8 and
+ * one of DRM_FORMAT_GR88.
+ * If VA_EXPORT_SURFACE_COMPOSED_LAYERS is specified on export,
+ * there will be exactly one layer.
+ */
+typedef struct _VADRMPRIMESurfaceDescriptor {
+    /** Pixel format fourcc of the whole surface (VA_FOURCC_*). */
+    uint32_t fourcc;
+    /** Width of the surface. */
+    uint32_t width;
+    /** Height of the surface. */
+    uint32_t height;
+    /** Number of distinct DRM objects making up the surface. */
+    uint32_t num_objects;
+    /** Description of each object. */
+    struct {
+        /** DRM PRIME file descriptor for this object. */
+        int fd;
+        /** Total size of this object (may include regions which are
+         *  not part of the surface). */
+        uint32_t size;
+        /** Format modifier applied to this object. */
+        uint64_t drm_format_modifier;
+    } objects[4];
+    /** Number of layers making up the surface. */
+    uint32_t num_layers;
+    /** Description of each layer in the surface. */
+    struct {
+        /** DRM format fourcc of this layer (DRM_FOURCC_*). */
+        uint32_t drm_format;
+        /** Number of planes in this layer. */
+        uint32_t num_planes;
+        /** Index in the objects array of the object containing each
+         *  plane. */
+        uint32_t object_index[4];
+        /** Offset within the object of each plane. */
+        uint32_t offset[4];
+        /** Pitch of each plane. */
+        uint32_t pitch[4];
+    } layers[4];
+} VADRMPRIMESurfaceDescriptor;
+
 
 #endif /* VA_DRM_COMMON_H */


### PR DESCRIPTION
Updated #85 (can't change source branch in github PRs).

The two component parts (add function, add DRM PRIME support) are now separate patches, otherwise this is the same as the previous version.