### PR TITLE
Add a route for drivers to send messages to the API message callbacks

### DIFF
--- a/va/drm/va_drm.c
+++ b/va/drm/va_drm.c
@@ -102,22 +102,23 @@ vaGetDisplayDRM(int fd)
         goto error;
     drm_state->fd = fd;
 
-    pDriverContext = calloc(1, sizeof(*pDriverContext));
+    pDisplayContext = va_newDisplayContext();
+    if (!pDisplayContext)
+        goto error;
+
+    pDisplayContext->vaIsValid       = va_DisplayContextIsValid;
+    pDisplayContext->vaDestroy       = va_DisplayContextDestroy;
+    pDisplayContext->vaGetDriverName = va_DisplayContextGetDriverName;
+
+    pDriverContext = va_newDriverContext(pDisplayContext);
     if (!pDriverContext)
         goto error;
+
     pDriverContext->native_dpy   = NULL;
     pDriverContext->display_type = is_render_nodes ?
         VA_DISPLAY_DRM_RENDERNODES : VA_DISPLAY_DRM;
     pDriverContext->drm_state    = drm_state;
 
-    pDisplayContext = va_newDisplayContext();
-    if (!pDisplayContext)
-        goto error;
-
-    pDisplayContext->pDriverContext  = pDriverContext;
-    pDisplayContext->vaIsValid       = va_DisplayContextIsValid;
-    pDisplayContext->vaDestroy       = va_DisplayContextDestroy;
-    pDisplayContext->vaGetDriverName = va_DisplayContextGetDriverName;
     return pDisplayContext;
 
 error:

--- a/va/va.c
+++ b/va/va.c
@@ -261,6 +261,24 @@ void va_infoMessage(VADisplay dpy, const char *msg, ...)
 #endif
 }
 
+static void va_driverErrorCallback(VADriverContextP ctx,
+                                   const char *message)
+{
+    VADisplayContextP dctx = ctx->pDisplayContext;
+    if (!dctx)
+        return;
+    dctx->error_callback(dctx->error_callback_user_context, message);
+}
+
+static void va_driverInfoCallback(VADriverContextP ctx,
+                                  const char *message)
+{
+    VADisplayContextP dctx = ctx->pDisplayContext;
+    if (!dctx)
+        return;
+    dctx->info_callback(dctx->info_callback_user_context, message);
+}
+
 VADisplayContextP va_newDisplayContext(void)
 {
     VADisplayContextP dctx = calloc(1, sizeof(*dctx));
@@ -282,6 +300,10 @@ VADriverContextP va_newDriverContext(VADisplayContextP dctx)
         return NULL;
 
     dctx->pDriverContext = ctx;
+    ctx->pDisplayContext = dctx;
+
+    ctx->error_callback = va_driverErrorCallback;
+    ctx->info_callback  = va_driverInfoCallback;
 
     return ctx;
 }

--- a/va/va.c
+++ b/va/va.c
@@ -275,6 +275,17 @@ VADisplayContextP va_newDisplayContext(void)
     return dctx;
 }
 
+VADriverContextP va_newDriverContext(VADisplayContextP dctx)
+{
+    VADriverContextP ctx = calloc(1, sizeof(*ctx));
+    if (!ctx)
+        return NULL;
+
+    dctx->pDriverContext = ctx;
+
+    return ctx;
+}
+
 static bool va_checkVtable(VADisplay dpy, void *ptr, char *function)
 {
     if (!ptr) {

--- a/va/va_backend.h
+++ b/va/va_backend.h
@@ -552,7 +552,48 @@ struct VADriverContext
 
     char *override_driver_name;
 
-    unsigned long reserved[41];         /* reserve for future add-ins, decrease the subscript accordingly */
+    void *pDisplayContext;
+
+    /**
+     * Error callback.
+     *
+     * This is set by libva when the driver is opened, and will not be
+     * changed thereafter.  The driver can call it with an error message,
+     * which will be propagated to the API user through their error
+     * callbacks, or sent to a default output if no callback is available.
+     *
+     * It is expected that end users will always be able to see these
+     * messages, so it should be called only for serious errors.  For
+     * example, hardware problems or fatal configuration errors.
+     *
+     * @param pDriverContext  Pointer to the driver context structure
+     *                        being used by the current driver.
+     * @param message  Message to send to the API user.  This must be a
+     *                 null-terminated string.
+     */
+    void (*error_callback)(VADriverContextP pDriverContext,
+                           const char *message);
+    /**
+     * Info callback.
+     *
+     * This has the same behaviour as the error callback, but has its
+     * own set of callbacks to the API user.
+     *
+     * It should be used for informational messages which may be useful
+     * for an application programmer or for debugging.  For example, minor
+     * configuration errors, or information about the reason when another
+     * API call generates an error return.  It is not expected that end
+     * users will see these messages.
+     *
+     * @param pDriverContext  Pointer to the driver context structure
+     *                        being used by the current driver.
+     * @param message  Message to send to the API user.  This must be a
+     *                 null-terminated string.
+     */
+    void (*info_callback)(VADriverContextP pDriverContext,
+                          const char *message);
+
+    unsigned long reserved[38];         /* reserve for future add-ins, decrease the subscript accordingly */
 };
 
 #define VA_DISPLAY_MAGIC 0x56414430 /* VAD0 */

--- a/va/va_internal.h
+++ b/va/va_internal.h
@@ -39,6 +39,8 @@ int  va_parseConfig(char *env, char *env_value);
 
 VADisplayContextP va_newDisplayContext(void);
 
+VADriverContextP va_newDriverContext(VADisplayContextP dctx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/va/wayland/va_wayland.c
+++ b/va/wayland/va_wayland.c
@@ -129,10 +129,9 @@ vaGetDisplayWl(struct wl_display *display)
     pDisplayContext->vaDestroy          = va_DisplayContextDestroy;
     pDisplayContext->vaGetDriverName    = va_DisplayContextGetDriverName;
 
-    pDriverContext = calloc(1, sizeof(*pDriverContext));
+    pDriverContext = va_newDriverContext(pDisplayContext);
     if (!pDriverContext)
         goto error;
-    pDisplayContext->pDriverContext     = pDriverContext;
 
     pDriverContext->native_dpy          = display;
     pDriverContext->display_type        = VA_DISPLAY_WAYLAND;


### PR DESCRIPTION
The important thing here is to make logging easier from drivers.  Currently the only logging route they have is stderr, which isn't necessarily visible anywhere and can causes problems for end users when messages appear on the console - drivers therefore avoid logging anything at all except in exceptional circumstances.  With this mechanism, hopefully drivers can log more useful information for application developers to assist development and debugging, particularly around the more complex parameter structures which have a large number of poorly-documented requirements.