### PR TITLE
Add fields for intensity compensation in VC-1 interlaced decoding

### DIFF
--- a/va/va.h
+++ b/va/va.h
@@ -2072,8 +2072,12 @@ typedef struct _VAPictureParameterBufferVC1
         uint32_t value;
     } transform_fields;
 
+    uint8_t luma_scale2;                  /* PICTURE_LAYER::LUMSCALE2 */
+    uint8_t luma_shift2;                  /* PICTURE_LAYER::LUMSHIFT2 */
+    uint8_t intensity_compensation_field; /* Index for PICTURE_LAYER::INTCOMPFIELD value in Table 109 (9.1.1.48) */
+
     /** \brief Reserved bytes for future use, must be zero */
-    uint32_t                va_reserved[VA_PADDING_MEDIUM];
+    uint32_t                va_reserved[VA_PADDING_MEDIUM - 1];
 } VAPictureParameterBufferVC1;
 
 /** VC-1 Bitplane Buffer


### PR DESCRIPTION
Intensity compensation in P interlaced field pictures needs more elements from the VC-1 bitstream. This change sets the stage for 01org/intel-vaapi-driver#295 that adds VC-1 decoding for interlaced content.

Signed-off-by: Jerome Borsboom <jerome.borsboom@carpalis.nl>