### PR TITLE
va_drm: dlopen correct version of libva-x11

### DIFF
--- a/va/drm/Makefile.am
+++ b/va/drm/Makefile.am
@@ -46,6 +46,7 @@ source_h_priv = \
 if USE_X11
 source_c			+= va_drm_auth_x11.c
 AM_CPPFLAGS			+= $(X11_CFLAGS)
+AM_CPPFLAGS			+= -DLIBVA_MAJOR_VERSION=$(LIBVA_MAJOR_VERSION)
 endif
 
 noinst_LTLIBRARIES		= libva_drm.la

--- a/va/drm/va_drm_auth_x11.c
+++ b/va/drm/va_drm_auth_x11.c
@@ -28,8 +28,6 @@
 #include <X11/Xlib.h>
 #include "va_drm_auth_x11.h"
 
-#define LIBVA_MAJOR_VERSION 1
-
 typedef struct drm_auth_x11             DRMAuthX11;
 typedef struct drm_auth_x11_vtable      DRMAuthX11VTable;
 


### PR DESCRIPTION
Signed-off-by: Sebastian Ramacher <sramacher@debian.org>