### PR TITLE
coverity: fix check_return and check_after_deref

### DIFF
--- a/va/x11/dri2_util.c
+++ b/va/x11/dri2_util.c
@@ -215,8 +215,7 @@ va_isDRI2Connected(VADriverContextP ctx, char **driver_name)
     dri_state->close = dri2Close;
     gsDRI2SwapAvailable = (minor >= 2);
 
-    if (device_name)
-        Xfree(device_name);
+    Xfree(device_name);
 
     return True;
 


### PR DESCRIPTION
This patch fixes two warnings provided by static code analysis tool
coverity.

- /va/x11/dri2_util.c:
> libva-1.8.3/va/x11/dri2_util.c:218: check_after_deref: Null-checking
> "device_name" suggests that it may be null, but it has already been
> dereferenced on all paths leading to the check.

- va/va_fool.c
> libva-1.8.3/va/va_fool.c:316: check_return:
> Calling "fstat(fd, &file_stat)" without checking return value.
> This library function may fail and return an error code.

Signed-off-by: Victor Toso <victortoso@redhat.com>