### PR TITLE
build: Remove unused macro

### DIFF
--- a/va/drm/Makefile.am
+++ b/va/drm/Makefile.am
@@ -21,7 +21,6 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 AM_CPPFLAGS = \
-	-DLINUX			\
 	-I$(top_srcdir)		\
 	-I$(top_srcdir)/va	\
 	$(DRM_CFLAGS)		\

--- a/va/glx/Makefile.am
+++ b/va/glx/Makefile.am
@@ -21,7 +21,6 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 AM_CPPFLAGS = \
-	-DLINUX			\
 	-I$(top_srcdir)		\
 	-I$(top_srcdir)/va	\
 	-I$(top_srcdir)/va/x11	\

--- a/va/wayland/Makefile.am
+++ b/va/wayland/Makefile.am
@@ -21,7 +21,6 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 AM_CPPFLAGS = \
-	-DLINUX			\
 	-I$(top_srcdir)		\
 	-I$(top_srcdir)/va	\
 	$(WAYLAND_CFLAGS)	\
@@ -73,7 +72,7 @@ va_wayland_drm.c: $(protocol_source_h)
 %-client-protocol.c: %-client-protocol-export.c
 	$(AM_V_GEN)$(SED) -e '1i#include "sysdeps.h"' \
 	                   -e 's@WL_EXPORT@DLL_HIDDEN@g' < $< > $@
-	
+
 EXTRA_DIST = \
 	wayland-drm.xml         \
 	$(NULL)

--- a/va/x11/Makefile.am
+++ b/va/x11/Makefile.am
@@ -21,7 +21,6 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 AM_CPPFLAGS = \
-	-DLINUX			\
 	-I$(top_srcdir)		\
 	-I$(top_srcdir)/va	\
 	$(X11_CFLAGS)		\


### PR DESCRIPTION
Remove -DLINUX macro definition as compiler parameters because it is
not used.

Fixes: #147