### PR TITLE
configure: set strict default compiler flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -301,6 +301,9 @@ if test "$USE_DRM:$USE_X11:$USE_WAYLAND" = "no:no:no"; then
     AC_MSG_ERROR([Please select at least one backend (DRM, X11, Wayland)])
 fi
 
+AC_SUBST([AM_CFLAGS], ["-Wall -Werror"])
+AC_SUBST([AM_CXXFLAGS], ["-Wall -Werror"])
+
 AC_OUTPUT([
     Makefile
     doc/Makefile


### PR DESCRIPTION
Use -Wall -Werror compiler flags for stricter compilation.

Fixes #146

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>