### PR TITLE
Make older versions of GCC happy

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -301,8 +301,8 @@ if test "$USE_DRM:$USE_X11:$USE_WAYLAND" = "no:no:no"; then
     AC_MSG_ERROR([Please select at least one backend (DRM, X11, Wayland)])
 fi
 
-AC_SUBST([AM_CFLAGS], ["-Wall -Werror"])
-AC_SUBST([AM_CXXFLAGS], ["-Wall -Werror"])
+AC_SUBST([AM_CFLAGS], ["-Wall -Werror -Wno-maybe-uninitialized"])
+AC_SUBST([AM_CXXFLAGS], ["-Wall -Werror -Wno-maybe-uninitialized"])
 
 AC_OUTPUT([
     Makefile


### PR DESCRIPTION
Some older versions of GCC fail to build libva since -Wall -Werror compiler
flags are used for stricter compilation

  CC       va_fglrx.lo
va_fglrx.c: In function 'VA_FGLRXGetClientDriverName':
va_fglrx.c:243:33: error: 'ADL_Main_Control_Destroy' may be used uninitialized in this function [-Werror=maybe-uninitialized]

From the code path, ADL_Main_Control_Destroy has been initialized if is_adl_initialized is 1.
however the older versions of GCC are not smart enough for an automatic variable, so I ignore
the error using -Wno-maybe-uninitialized

This fixes https://github.com/01org/libva/issues/152

Signed-off-by: Xiang, Haihao <haihao.xiang@intel.com>