### PR TITLE
X11: sync xerrors before unset error handler

### DIFF
--- a/va/x11/va_dricommon.c
+++ b/va/x11/va_dricommon.c
@@ -55,6 +55,7 @@ is_window(Display *dpy, Drawable drawable)
 
     x11_trap_errors();
     XGetWindowAttributes(dpy, drawable, &wattr);
+    XSync(dpy, False);
     return x11_untrap_errors() == 0;
 }
 


### PR DESCRIPTION
fix for #151 vaPutSurface XError race condition with X11 pixmap