### PR TITLE
Revert "configure: set strict default compiler flags"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -301,9 +301,6 @@ if test "$USE_DRM:$USE_X11:$USE_WAYLAND" = "no:no:no"; then
     AC_MSG_ERROR([Please select at least one backend (DRM, X11, Wayland)])
 fi
 
-AC_SUBST([AM_CFLAGS], ["-Wall -Werror"])
-AC_SUBST([AM_CXXFLAGS], ["-Wall -Werror"])
-
 AC_OUTPUT([
     Makefile
     doc/Makefile


### PR DESCRIPTION
This reverts commit 6ca99be5042558035a78ffa87cfcd853611591cc.

Strict compilation flags are not consistent across different
versions of GCC and cause issues for users with older GCC
versions.

Since we have little control over which compiler version
is used by user, ensuring that strict compilation works properly
across all known used compilers would be a maintenance
headache.

Instead, don't enforce strict compilation and let users choose
when to enforce it via user-defined C/CXXFLAGS.

Fixes #152

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>