### PR TITLE
trace: init mutex before attempting to lock it

### DIFF
--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -743,6 +743,9 @@ void va_TraceInit(VADisplay dpy)
 
     pva_trace->dpy = dpy;
 
+    pthread_mutex_init(&pva_trace->resource_mutex, NULL);
+    pthread_mutex_init(&pva_trace->context_mutex, NULL);
+
     if (va_parseConfig("LIBVA_TRACE", &env_value[0]) == 0) {
         pva_trace->fn_log_env = strdup(env_value);
         trace_ctx->plog_file = start_tracing2log_file(pva_trace);
@@ -804,9 +807,6 @@ void va_TraceInit(VADisplay dpy)
                            trace_ctx->trace_surface_yoff);
         }
     }
-
-    pthread_mutex_init(&pva_trace->resource_mutex, NULL);
-    pthread_mutex_init(&pva_trace->context_mutex, NULL);
 
     trace_ctx->trace_context = VA_INVALID_ID;
     pva_trace->ptra_ctx[MAX_TRACE_CTX_NUM] = trace_ctx;


### PR DESCRIPTION
Call pthread_mutex_init before any calls to pthread_mutex_lock.

va_TraceInit(...) calls start_tracing2log_file(...) which
calls pthread_mutex_lock on the pva_trace->resource_mutex.
Thus, we need to ensure the mutex is initialized properly via
pthread_mutex_init before attempting to lock it.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>