### PR TITLE
remove max_display_attributes value check.

### DIFF
--- a/va/va.c
+++ b/va/va.c
@@ -451,7 +451,6 @@ static VAStatus va_openDriver(VADisplay dpy, char *driver_name)
                     CHECK_MAXIMUM(vaStatus, ctx, attributes);
                     CHECK_MAXIMUM(vaStatus, ctx, image_formats);
                     CHECK_MAXIMUM(vaStatus, ctx, subpic_formats);
-                    CHECK_MAXIMUM(vaStatus, ctx, display_attributes);
                     CHECK_STRING(vaStatus, ctx, vendor);
                     CHECK_VTABLE(vaStatus, ctx, Terminate);
                     CHECK_VTABLE(vaStatus, ctx, QueryConfigProfiles);


### PR DESCRIPTION
max_display_attributes maybe is zero, because driver dont support display attribute

Signed-off-by: XinfengZhang <carl.zhang@intel.com>

some discussion is in https://github.com/intel/media-driver/issues/17