### PR TITLE
va_trace: Remove unused variable

### DIFF
--- a/va/va_trace.c
+++ b/va/va_trace.c
@@ -267,7 +267,6 @@ static int get_valid_config_idx(
     struct va_trace *pva_trace,
     VAConfigID config_id)
 {
-    struct trace_config_info *pconfig_info;
     int idx = MAX_TRACE_CTX_NUM;
 
     LOCK_RESOURCE(pva_trace);


### PR DESCRIPTION
Leftover from recent commit 35d7d312d45f9fd42dd

> va_trace.c:270:31: warning: unused variable 'pconfig_info'
>     struct trace_config_info *pconfig_info;
>                               ^

Signed-off-by: Victor Toso <victortoso@redhat.com>