### PR TITLE
Add control to use avc VME to get intra prediction mode for HEVC FEI

### DIFF
--- a/va/va_fei_hevc.h
+++ b/va/va_fei_hevc.h
@@ -165,7 +165,9 @@ typedef struct _VAEncMiscParameterFEIFrameControlHEVC
     uint32_t      search_window             : 8;
     /** \brief number of internal MV predictors for IME searches */
     uint32_t      max_num_ime_search_center : 3;
-    uint32_t      reserved2                 : 5;
+    /** \brief only use AVC VME to get intra prediction mode */
+    uint32_t      use_avc_intra_mode_only   : 1;
+    uint32_t      reserved2                 : 4;
 
     /** \brief specifies number of splits that encoder could be run concurrently
      * 1: level 1, default value


### PR DESCRIPTION
Signed-off-by: dlin2 <decai.lin@intel.com>